### PR TITLE
Bug fix for label argument inside ggplot2::geom_text

### DIFF
--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -182,7 +182,8 @@ ggcorrplot <- function (corr, method = c("square", "circle"),
   if (lab)
     p <- p +
     ggplot2::geom_text(
-      ggplot2::aes_string("Var1", "Var2", label = label),
+      ggplot2::aes_string("Var1", "Var2"),
+      label = label,
       color = lab_col, size = lab_size
     )
 


### PR DESCRIPTION
label = label should be outside ggplot2::aes_string, not inside, otherwise only the first element in the label vector is taken as a constant