### PR TITLE
integrate a scaling factor for circles

### DIFF
--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -108,8 +108,8 @@ ggcorrplot <- function (corr, method = c("square", "circle"),
                         type = c("full", "lower", "upper"),
                         ggtheme = ggplot2::theme_minimal,
                         title = "", show.legend = TRUE, legend.title = "Corr", show.diag = FALSE,
-                        colors = c("blue", "white", "red"), outline.color = "gray",
-                        hc.order = FALSE, hc.method = "complete",
+                        colors = c("blue", "white", "red"), colors.position = c(-1, 0, 1),
+                        outline.color = "gray", hc.order = FALSE, hc.method = "complete",
                         lab = FALSE, lab_col = "black", lab_size = 4,
                         p.mat = NULL, sig.level = 0.05, insig = c("pch", "blank"),
                         pch = 4, pch.col = "black", pch.cex = 5,
@@ -165,14 +165,14 @@ ggcorrplot <- function (corr, method = c("square", "circle"),
   else if (method == "circle") {
     p <- p + ggplot2::geom_point(color = outline.color,
                                  shape = 21, ggplot2::aes_string(size = "abs_corr")) +
-      ggplot2::scale_size(range = c(4, 10*circle.scale)) + ggplot2::guides(size = FALSE)
+      ggplot2::scale_size(range = c(4, 10*circle.scale)) + ggplot2::guides(fill = guide_colorbar(barwidth = 8, barheight = 1, raster=TRUE, title=""), size = FALSE)
   }
 
   p <-
-    p + ggplot2::scale_fill_gradient2(
-      low = colors[1], high = colors[3], mid = colors[2],
-      midpoint = 0, limit = c(-1,1), space = "Lab",
-      name = legend.title
+    p + ggplot2::scale_fill_gradientn(
+      colours = colors,
+      values = colors.position,
+      limit = c(-1,1)
     ) +
     ggtheme()
 
@@ -185,7 +185,7 @@ ggcorrplot <- function (corr, method = c("square", "circle"),
           angle = tl.srt, vjust = 0, size = tl.cex, hjust = 0
         ),
         axis.text.y = ggplot2::element_text(hjust=0, size = tl.cex),
-        legend.position = "left"
+        legend.position = "bottom"
       )
   } else {
     p <- 

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -39,6 +39,8 @@
 #'   insig is "pch").
 #' @param tl.cex,tl.col,tl.srt the size, the color and the string rotation of
 #'   text label (variable names).
+#' @param circle.scale to be used as a scaling factor for circles. Depending on
+#'   the output device it may be necessary to adjust this parameter.
 #' @return
 #' \itemize{
 #'  \item ggcorrplot(): Returns a ggplot2
@@ -110,7 +112,8 @@ ggcorrplot <- function (corr, method = c("square", "circle"),
                         lab = FALSE, lab_col = "black", lab_size = 4,
                         p.mat = NULL, sig.level = 0.05, insig = c("pch", "blank"),
                         pch = 4, pch.col = "black", pch.cex = 5,
-                        tl.cex = 12, tl.col = "black", tl.srt = 45) {
+                        tl.cex = 12, tl.col = "black", tl.srt = 45,
+                        circle.scale = 1) {
 
   type <- match.arg(type)
   method <- match.arg(method)
@@ -151,7 +154,7 @@ ggcorrplot <- function (corr, method = c("square", "circle"),
       corr$value <- corr$value * corr$signif
   }
 
-  corr$abs_corr <- abs(corr$value) * 10
+  corr$abs_corr <- abs(corr$value) * 10 * circle.scale
 
   # Heatmap
   p <-
@@ -161,7 +164,7 @@ ggcorrplot <- function (corr, method = c("square", "circle"),
   else if (method == "circle") {
     p <- p + ggplot2::geom_point(color = outline.color,
                                  shape = 21, ggplot2::aes_string(size = "abs_corr")) +
-      ggplot2::scale_size(range = c(4, 10)) + ggplot2::guides(size = FALSE)
+      ggplot2::scale_size(range = c(4, 10*circle.scale)) + ggplot2::guides(size = FALSE)
   }
 
   p <-

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -41,6 +41,7 @@
 #'   text label (variable names).
 #' @param circle.scale to be used as a scaling factor for circles. Depending on
 #'   the output device it may be necessary to adjust this parameter.
+#' @param mirror.axis.text logical value. If TRUE, axis text of plot is mirrored
 #' @return
 #' \itemize{
 #'  \item ggcorrplot(): Returns a ggplot2
@@ -113,7 +114,7 @@ ggcorrplot <- function (corr, method = c("square", "circle"),
                         p.mat = NULL, sig.level = 0.05, insig = c("pch", "blank"),
                         pch = 4, pch.col = "black", pch.cex = 5,
                         tl.cex = 12, tl.col = "black", tl.srt = 45,
-                        circle.scale = 1) {
+                        circle.scale = 1, mirror.axis.text = F) {
 
   type <- match.arg(type)
   method <- match.arg(method)
@@ -173,14 +174,29 @@ ggcorrplot <- function (corr, method = c("square", "circle"),
       midpoint = 0, limit = c(-1,1), space = "Lab",
       name = legend.title
     ) +
-    ggtheme() +
-    ggplot2::theme(
+    ggtheme()
+
+  if(mirror.axis.text) {
+    p <- 
+      p + scale_x_discrete(position = "top") +
+      scale_y_discrete(position = "right") +
+      ggplot2::theme(
+        axis.text.x = ggplot2::element_text(
+          angle = tl.srt, vjust = 0, size = tl.cex, hjust = 0
+        ),
+        axis.text.y = ggplot2::element_text(hjust=0, size = tl.cex),
+        legend.position = "left"
+      )
+  } else {
+    p <- 
+      p + ggplot2::theme(
       axis.text.x = ggplot2::element_text(
         angle = tl.srt, vjust = 1, size = tl.cex, hjust = 1
       ),
-      axis.text.y = ggplot2::element_text(size = tl.cex)
-    ) +
-    ggplot2::coord_fixed()
+      axis.text.y = ggplot2::element_text(hjust=0, size = tl.cex)
+    )
+  }
+  p <- p + ggplot2::coord_fixed() 
 
   label <- round(corr[, "value"], 2)
   if (lab)


### PR DESCRIPTION
I'm using your excellent correlation plot package with knitr and noticed that depending on the output size of the figure circles are either to small or to large. In most cases the default setting is ok but from time to time a little adjustment is needed.

This commit gives the user some freedom at least in this regard :)