### PR TITLE
Added 'as.is' passed to reshape2::melt.array().

### DIFF
--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -42,6 +42,9 @@
 #'   text label (variable names).
 #' @param digits Decides the number of decimal digits to be displayed (Default:
 #'   `2`).
+#' @param as.is A logical passed to \code{\link[reshape2]{melt.array}}. If
+#' \code{TRUE}, dimnames will be left as strings instead of being converted
+#' using \code{\link[utils]{type.convert}}.
 #' @return
 #' \itemize{
 #'  \item ggcorrplot(): Returns a ggplot2
@@ -151,7 +154,8 @@ ggcorrplot <- function(corr,
                        tl.cex = 12,
                        tl.col = "black",
                        tl.srt = 45,
-                       digits = 2) {
+                       digits = 2,
+                       as.is = FALSE) {
   type <- match.arg(type)
   method <- match.arg(method)
   insig <- match.arg(insig)
@@ -190,7 +194,7 @@ ggcorrplot <- function(corr,
   }
 
   # Melt corr and pmat
-  corr <- reshape2::melt(corr, na.rm = TRUE)
+  corr <- reshape2::melt(corr, na.rm = TRUE, as.is = as.is)
   colnames(corr) <- c("Var1", "Var2", "value")
   corr$pvalue <- rep(NA, nrow(corr))
   corr$signif <- rep(NA, nrow(corr))

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -13,7 +13,7 @@ ggcorrplot(corr, method = c("square", "circle"), type = c("full",
   lab_col = "black", lab_size = 4, p.mat = NULL, sig.level = 0.05,
   insig = c("pch", "blank"), pch = 4, pch.col = "black",
   pch.cex = 5, tl.cex = 12, tl.col = "black", tl.srt = 45,
-  digits = 2)
+  digits = 2, as.is = FALSE)
 
 cor_pmat(x, ...)
 }
@@ -77,6 +77,10 @@ text label (variable names).}
 
 \item{digits}{Decides the number of decimal digits to be displayed (Default:
 `2`).}
+
+\item{as.is}{A logical passed to \code{\link[reshape2]{melt.array}}. If
+\code{TRUE}, dimnames will be left as strings instead of being converted
+using \code{\link[utils]{type.convert}}.}
 
 \item{x}{numeric matrix or data frame}
 


### PR DESCRIPTION
Numeric-style dimnames (see [sample data](https://github.com/kassambara/ggcorrplot/files/3554568/out_tt1.1.rds.zip)) are currently being converted to numeric by `reshape2::melt.array()`. Since this is not always desirable, I believe a customization option should be made available to the user. 

In my particular case, dimnames '01' to '12' are sample names that I want to appear as categorical rather than continuous features in the resulting plot. Current behavior:

```r
out_tt1.1 = readRDS("C:/Users/florianD/Downloads/out_tt1.1.rds")

ggcorrplot::ggcorrplot(out_tt1.1, type = "upper", p.mat = out_tt1.1
                       , show.diag = TRUE) + 
  scale_fill_gradient2(bquote(bold("p-value")), limit = c(0, 1), midpoint = 0.5
                       , low = "#460000", high =  "#EBEAF7", mid = "#B5BD4C")
```
![current](https://user-images.githubusercontent.com/3940660/63924327-5e4be900-ca48-11e9-983e-d1b93f9d533c.png)

With adjustments:

```r
ggcorrplot::ggcorrplot(out_tt1.1, type = "upper", p.mat = out_tt1.1
                       , show.diag = TRUE, as.is = TRUE) + 
  scale_fill_gradient2(bquote(bold("p-value")), limit = c(0, 1), midpoint = 0.5
                       , low = "#460000", high =  "#EBEAF7", mid = "#B5BD4C")
``` 
![adjusted](https://user-images.githubusercontent.com/3940660/63924348-67d55100-ca48-11e9-9cec-52aa4d9ebef7.png)
