### PR TITLE
Suggested fix for `hc.method` bug.

### DIFF
--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -175,7 +175,9 @@ ggcorrplot <- function(corr,
   corr <- base::round(x = corr, digits = digits)
 
   if (hc.order) {
-    ord <- .hc_cormat_order(corr)
+    dd <- stats::as.dist((1 - corr) / 2)
+    hc <- stats::hclust(dd, method = hc.method)
+    ord <- hc$order
     corr <- corr[ord, ord]
     if (!is.null(p.mat)) {
       p.mat <- p.mat[ord, ord]
@@ -373,13 +375,6 @@ cor_pmat <- function(x, ...) {
     diag(cormat) <- NA
   }
   return(cormat)
-}
-
-# hc.order correlation matrix
-.hc_cormat_order <- function(cormat, hc.method = "complete") {
-  dd <- stats::as.dist((1 - cormat) / 2)
-  hc <- stats::hclust(dd, method = hc.method)
-  hc$order
 }
 
 .no_panel <- function() {


### PR DESCRIPTION
Firstly, thanks very much. This function is super useful for the
exploratory data analysis that I’m often required to do for work. In
particular, the `hc.order` argument makes the final graph very visually
appealing and easy to interpret.

I was playing around with the `hc.method` argument today and realised
that choosing a different linkage criterion was not having an effect on
the order of the variables in the final visualisation.

Here’s a representative example:

    # Fake data
    set.seed(1)
    master <- tibble::tibble(var_1 = rnorm(100),
                             var_2 = 1*var_1  + rnorm(100), # positive corr
                             var_3 = rnorm(100),
                             var_4 = rnorm(100),
                             var_5 = rnorm(100),
                             var_6 = rnorm(100),
                             var_7 = rnorm(100),
                             var_8 = -1*var_4 + rnorm(100)) # negative corr

    # Get correlations
    pearson <- stats::cor(master, method = "pearson")

Compare the different linkage methods:

    # Corrplot ordered by hierarchical clustering with different linkage criteria
    ggcorrplot::ggcorrplot(pearson, hc.order = T, hc.method = "complete")

![image](https://user-images.githubusercontent.com/53878447/80400666-05707100-88b3-11ea-894d-25c541c83a3e.png)

    ggcorrplot::ggcorrplot(pearson, hc.order = T, hc.method = "single")

![image](https://user-images.githubusercontent.com/53878447/80400702-14efba00-88b3-11ea-9ce4-43f108413261.png)

    ggcorrplot::ggcorrplot(pearson, hc.order = T, hc.method = "average")

![image](https://user-images.githubusercontent.com/53878447/80400761-2d5fd480-88b3-11ea-968d-de9f11576f50.png)

The `hc.method` argument is having no effect.

So, I did the clustering manually to check if the order should be
changing.

    # Do hierarchical clustering manually as the function does

    # First, it rounds the correlations to 2 digits by default
    rounded <- round(pearson, 2)
    # Then it calculates distance
    dist <- as.dist((1 - rounded)/2)
    # Then it runs clustering with specified method
    complete_hclust <- hclust(dist, method = "complete")
    complete_hclust$order

    ## [1] 7 8 5 1 2 6 3 4

    single_hclust <- hclust(dist, method = "single")
    single_hclust$order

    ## [1] 6 5 1 2 7 8 3 4

    average_hclust <- hclust(dist, method = "average")
    average_hclust$order

    ## [1] 3 4 6 5 1 2 7 8

We can see that the order should be changing with the linkage criterion.

I think I the problem is the use of the helper
function`.hc_cormat_order` as I don’t think the user’s choice for the
the `hc.method` argument is being passed through to this helper
function. Instead the helper function default of
`hc.method = "complete"` is always being used.

I am submitting this pull request having removed the helper function
altogether and included the ordering process in the body of the main
function. As I could only see the helper function being used once I thought
removing it would be an acceptable solution.

When I use my modified version of the function the output matches the
order from the manual clustering:

    # Compare altered version of corrplot function with dendogram from manual clustering
    plot(complete_hclust, main = "Complete linkage")

![image](https://user-images.githubusercontent.com/53878447/80400884-5b451900-88b3-11ea-8113-a8145e4b84e6.png)

    ggcorrplot(pearson, hc.order = T, hc.method = "complete")

![image](https://user-images.githubusercontent.com/53878447/80400908-65671780-88b3-11ea-8192-1ebbd96be1ee.png)

    plot(single_hclust, main = "Single linkage")

![image](https://user-images.githubusercontent.com/53878447/80400934-7021ac80-88b3-11ea-8e05-e0546dc89631.png)

    ggcorrplot(pearson, hc.order = T, hc.method = "single")

![image](https://user-images.githubusercontent.com/53878447/80400965-7ca60500-88b3-11ea-9c80-2edcaa3ee107.png)

    plot(average_hclust, main = "Average linkage")

![image](https://user-images.githubusercontent.com/53878447/80401002-87609a00-88b3-11ea-97e5-748dc1512002.png)

    ggcorrplot(pearson, hc.order = T, hc.method = "average")

![image](https://user-images.githubusercontent.com/53878447/80401056-a101e180-88b3-11ea-8c73-b21c9e629f55.png)

This is my first attempt at a contribution to an open source package. So, apologies if I've not done anything by the book. 

Thanks again for your work developing the function.