### PR TITLE
flip orientation of diagonal

### DIFF
--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -364,7 +364,7 @@ cor_pmat <- function(x, ...) {
   if (is.null(cormat)) {
     return(cormat)
   }
-  cormat[upper.tri(cormat)] <- NA
+  cormat[lower.tri(cormat)] <- NA
   if (!show.diag) {
     diag(cormat) <- NA
   }
@@ -376,7 +376,7 @@ cor_pmat <- function(x, ...) {
   if (is.null(cormat)) {
     return(cormat)
   }
-  cormat[lower.tri(cormat)] <- NA
+  cormat[upper.tri(cormat)] <- NA
   if (!show.diag) {
     diag(cormat) <- NA
   }


### PR DESCRIPTION
Per [this issue](https://github.com/kassambara/ggcorrplot/issues/36), this fork changes two lines of code to flip the orientation of the diagonal when calling `type = "upper"` or `type = "lower"`.