### PR TITLE
Activate the tl.col argument and allow vectorized inputs.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,11 +16,12 @@ Depends:
     ggplot2
 Imports:
     reshape2,
-    stats
+    stats,
+    ggtext
 Suggests:
     knitr,
     spelling
 URL: http://www.sthda.com/english/wiki/ggcorrplot
 BugReports: https://github.com/kassambara/ggcorrplot/issues
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.2
 Language: en-US

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,3 +3,4 @@
 export(cor_pmat)
 export(ggcorrplot)
 import(ggplot2)
+import(ggtext)

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -1,5 +1,5 @@
 #' Visualization of a correlation matrix using ggplot2
-#' @import ggplot2
+#' @import ggplot2 ggtext
 #' @description \itemize{ \item ggcorrplot(): A graphical display of a
 #'   correlation matrix using ggplot2. \item cor_pmat(): Compute a correlation
 #'   matrix p-values. }
@@ -273,6 +273,8 @@ ggcorrplot <- function(corr,
       ),
       axis.text.y = ggplot2::element_text(size = tl.cex)
     ) +
+    ggplot2::theme(axis.text.x = ggtext::element_markdown(colour = tl.col),
+                   axis.text.y = ggtext::element_markdown(colour = tl.col))+
     ggplot2::coord_fixed()
 
   label <- round(x = corr[, "value"], digits = digits)


### PR DESCRIPTION
Hi,

I recently issued a problem with the `ggcorrplot` function not being able to use the` tl.col` argument [#44](https://github.com/kassambara/ggcorrplot/issues/44) .
I fixed it on a forked version and propose my changes to be added if you want.

I added ` tl.col` in the `theme` of the function using `ggtext::element_markdown()` to make it accept vectorized color input to display such correlation plots :

```r{}
# Compute a correlation matrix
data(mtcars)
corr <- round(cor(mtcars), 1)
head(corr[, 1:6])
#>       mpg  cyl disp   hp drat   wt
#> mpg   1.0 -0.9 -0.8 -0.8  0.7 -0.9
#> cyl  -0.9  1.0  0.9  0.8 -0.7  0.8
#> disp -0.8  0.9  1.0  0.8 -0.7  0.9
#> hp   -0.8  0.8  0.8  1.0 -0.4  0.7
#> drat  0.7 -0.7 -0.7 -0.4  1.0 -0.7
#> wt   -0.9  0.8  0.9  0.7 -0.7  1.0
```
# Compute a matrix of correlation p-values

```r{}
p.mat <- cor_pmat(mtcars)
head(p.mat[, 1:4])
#>               mpg          cyl         disp           hp
#> mpg  0.000000e+00 6.112687e-10 9.380327e-10 1.787835e-07
#> cyl  6.112687e-10 0.000000e+00 1.802838e-12 3.477861e-09
#> disp 9.380327e-10 1.802838e-12 0.000000e+00 7.142679e-08
#> hp   1.787835e-07 3.477861e-09 7.142679e-08 0.000000e+00
#> drat 1.776240e-05 8.244636e-06 5.282022e-06 9.988772e-03
#> wt   1.293959e-10 1.217567e-07 1.222320e-11 4.145827e-05
```
# Visualize the correlation matrix
# --------------------------------
# method = "square" (default)

```r{}
ggcorrplot(corr, tl.col = c(rep("red",4),rep("black",4),rep("purple",3))
```
![image](https://user-images.githubusercontent.com/49724216/149334272-136d245a-717d-48d0-ba0a-6bfff95a9191.png)



Thanks again for this amazing package!
Have a nice day!