### PR TITLE
Replace deprecated aes_string() with aes()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,11 @@
 
 - Removes warnings stemming from the latest version of `ggplot2`.
 
+- Replaced the deprecated `ggplot2::aes_string()` with tidy-evaluation `aes()`
+  internally, silencing the ggplot2 deprecation warnings on recent `ggplot2`
+  versions. Default output is unchanged (#57, #58, #59, #60, #61). Based on the
+  contribution by @jeherschberger (#62).
+
 ## Bug fixes
 
 - The option `hc.method` is now taken into account (#mitchelfruin, #29)

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -227,7 +227,7 @@ ggcorrplot <- function(corr,
   p <-
     ggplot2::ggplot(
       data = corr,
-      mapping = ggplot2::aes_string(x = "Var1", y = "Var2", fill = "value")
+      mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]], fill = .data[["value"]])
     )
 
   # modification based on method
@@ -239,7 +239,7 @@ ggcorrplot <- function(corr,
       ggplot2::geom_point(
         color = outline.color,
         shape = 21,
-        ggplot2::aes_string(size = "abs_corr")
+        ggplot2::aes(size = .data[["abs_corr"]])
       ) +
       ggplot2::scale_size(range = c(4, 10)) +
       ggplot2::guides(size = "none")
@@ -286,7 +286,7 @@ ggcorrplot <- function(corr,
   if (lab) {
     p <- p +
       ggplot2::geom_text(
-        mapping = ggplot2::aes_string(x = "Var1", y = "Var2"),
+        mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),
         label = label,
         color = lab_col,
         size = lab_size
@@ -297,7 +297,7 @@ ggcorrplot <- function(corr,
   if (!is.null(p.mat) & insig == "pch") {
     p <- p + ggplot2::geom_point(
       data = p.mat,
-      mapping = ggplot2::aes_string(x = "Var1", y = "Var2"),
+      mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),
       shape = pch,
       size = pch.cex,
       color = pch.col


### PR DESCRIPTION
Replaces the internal `ggplot2::aes_string()` calls with tidy-evaluation `aes()` (using the `.data` pronoun), silencing the deprecation warnings shown on recent `ggplot2` versions. The plotted output is unchanged.

Based on the contribution by @jeherschberger in #62.

Fixes #57. Refs #58, #59, #60, #61.