### PR TITLE
Add a CITATION file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,9 @@
   versions. Default output is unchanged (#57, #58, #59, #60, #61). Based on the
   contribution by @jeherschberger (#62).
 
+- Added a `CITATION` file so `citation("ggcorrplot")` returns a proper
+  reference (#42, #47).
+
 ## Bug fixes
 
 - The option `hc.method` is now taken into account (#mitchelfruin, #29)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,17 @@
+citHeader("To cite ggcorrplot in publications, please use:")
+
+year <- sub("-.*", "", meta$Date)
+if (length(year) == 0L || is.na(year) || !nzchar(year) ||
+    year > format(Sys.Date(), "%Y")) {
+  year <- format(Sys.Date(), "%Y")
+}
+note <- sprintf("R package version %s", meta$Version)
+
+bibentry(
+  bibtype  = "Manual",
+  title    = "{ggcorrplot}: Visualization of a Correlation Matrix using 'ggplot2'",
+  author   = person("Alboukadel", "Kassambara"),
+  year     = year,
+  note     = note,
+  url      = "https://CRAN.R-project.org/package=ggcorrplot"
+)


### PR DESCRIPTION
Adds `inst/CITATION` so `citation("ggcorrplot")` returns a proper reference (title, author, package version, CRAN URL) rather than the auto-generated fallback. The year is derived from the package metadata.

Fixes #42. Also resolves #47 (same request).