### PR TITLE
Fix p-value matrix handling: significance vs hc.order (#25) and as.is alignment (#37)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,17 @@
 
 ## Bug fixes
 
+- The significance test is no longer affected by `hc.order`. Previously, when
+  `hc.order = TRUE`, the p-value matrix was rounded to `digits` before being
+  compared with `sig.level`, so a p-value just above the threshold (e.g. 0.054)
+  could be shown as significant while the same data with `hc.order = FALSE`
+  showed it as non-significant (@worden-lee, #25).
+
+- The significance markers now stay aligned with the tiles when the matrix has
+  numeric-looking names. The p-value matrix is now reshaped with the same
+  `as.is` setting as the correlation matrix, so `as.is = TRUE` no longer places
+  the markers off-plot (@cabaez, #37).
+
 - The option `hc.method` is now taken into account (#mitchelfruin, #29)
 
 - The option `show.diag` now works for full matrix (@arbet003 , #31)

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -185,7 +185,6 @@ ggcorrplot <- function(corr,
     corr <- corr[ord, ord]
     if (!is.null(p.mat)) {
       p.mat <- p.mat[ord, ord]
-      p.mat <- base::round(x = p.mat, digits = digits)
     }
   }
 
@@ -210,7 +209,7 @@ ggcorrplot <- function(corr,
   corr$signif <- rep(NA, nrow(corr))
 
   if (!is.null(p.mat)) {
-    p.mat <- reshape2::melt(p.mat, na.rm = TRUE)
+    p.mat <- reshape2::melt(p.mat, na.rm = TRUE, as.is = as.is)
     corr$coef <- corr$value
     corr$pvalue <- p.mat$value
     corr$signif <- as.numeric(p.mat$value <= sig.level)

--- a/tests/testthat/test-pmat.R
+++ b/tests/testthat/test-pmat.R
@@ -1,0 +1,44 @@
+# Regression tests for p-value matrix handling (#25, #37)
+
+# Count the significance-marker (pch = 4 cross) glyphs in a built plot.
+.n_crosses <- function(p) {
+  b <- ggplot2::ggplot_build(p)$data
+  cl <- Filter(function(d) "shape" %in% names(d) && nrow(d) > 0 && all(d$shape == 4), b)
+  if (length(cl)) nrow(cl[[1]]) else 0L
+}
+
+test_that("hc.order does not alter significance via p-value rounding (#25)", {
+  cmat <- matrix(c(1, 0.3, 0.2, 0.3, 1, 0.25, 0.2, 0.25, 1), 3,
+                 dimnames = list(letters[1:3], letters[1:3]))
+  # p = 0.054 is just ABOVE the default sig.level (0.05); it must stay
+  # non-significant (a cross is drawn) whether or not hc.order is used.
+  pmat <- matrix(c(0, 0.054, 0.20, 0.054, 0, 0.30, 0.20, 0.30, 0), 3,
+                 dimnames = list(letters[1:3], letters[1:3]))
+  n_no_hc <- .n_crosses(ggcorrplot(cmat, p.mat = pmat, insig = "pch"))
+  n_hc    <- .n_crosses(ggcorrplot(cmat, p.mat = pmat, hc.order = TRUE, insig = "pch"))
+  # all 6 off-diagonal cells are non-significant -> 6 crosses either way
+  expect_equal(n_no_hc, 6L)
+  expect_equal(n_hc, n_no_hc)
+})
+
+test_that("hc.order leaves significance unchanged for non-boundary p (#25 no-regression)", {
+  corr <- round(cor(mtcars), 1)
+  p    <- cor_pmat(mtcars)
+  expect_equal(
+    .n_crosses(ggcorrplot(corr, p.mat = p, hc.order = TRUE,  insig = "pch")),
+    .n_crosses(ggcorrplot(corr, p.mat = p, hc.order = FALSE, insig = "pch"))
+  )
+})
+
+test_that("p.mat aligns with numeric-looking names when as.is = TRUE (#37)", {
+  nm <- c("10", "2", "33")
+  m  <- matrix(c(1, 0.8, 0.2, 0.8, 1, 0.1, 0.2, 0.1, 1), 3, dimnames = list(nm, nm))
+  pm <- matrix(c(0, 0.6, 0.9, 0.6, 0, 0.7, 0.9, 0.7, 0), 3, dimnames = list(nm, nm))
+  b  <- ggplot2::ggplot_build(ggcorrplot(m, p.mat = pm, as.is = TRUE, insig = "pch"))$data
+  cl <- Filter(function(d) "shape" %in% names(d) && nrow(d) > 0 && all(d$shape == 4), b)
+  expect_true(length(cl) > 0)
+  # crosses must land on the discrete tile positions (1..3), not the literal
+  # names (10, 33) that would otherwise place them off-plot.
+  expect_true(all(cl[[1]]$x %in% seq_len(3)))
+  expect_true(all(cl[[1]]$y %in% seq_len(3)))
+})


### PR DESCRIPTION
Two correctness fixes in the p-value-matrix handling.

**#25** — With `hc.order = TRUE`, the p-value matrix was rounded to `digits` before the significance test, so a p-value just above `sig.level` (e.g. 0.054 → 0.05) could be marked significant — disagreeing with the same data under `hc.order = FALSE`. The p-value matrix is no longer rounded; significance is now independent of `hc.order`.

**#37** — The p-value matrix was reshaped without the `as.is` setting used for the correlation matrix, so with numeric-looking names and `as.is = TRUE` the significance markers landed at the literal names (off-plot) instead of the tile positions. It now uses the same `as.is`.

Default output is unchanged: `as.is` defaults to `FALSE` (so #37 only affects explicit `as.is = TRUE`), and the rounding fix only changes cells whose p-value rounds across `sig.level` (none in the standard cases). Adds regression + no-regression tests.

Fixes #25. Fixes #37.