### PR TITLE
Apply the tl.col argument (color of axis text labels) (#44)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,10 @@
 
 ## Bug fixes
 
+- The `tl.col` argument (color of the axis text labels) is now applied; it was
+  previously ignored. It defaults to `NULL`, inheriting the color from the theme,
+  so the default appearance is unchanged (@LafontRapnouilTristan, #44, #45).
+
 - The significance test is no longer affected by `hc.order`. Previously, when
   `hc.order = TRUE`, the p-value matrix was rounded to `digits` before being
   compared with `sig.level`, so a p-value just above the threshold (e.g. 0.054)

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -41,7 +41,8 @@
 #' @param pch.col,pch.cex the color and the cex (size) of pch (only valid when
 #'   insig is "pch").
 #' @param tl.cex,tl.col,tl.srt the size, the color and the string rotation of
-#'   text label (variable names).
+#'   text label (variable names). \code{tl.col} defaults to \code{NULL}, which
+#'   inherits the color from the theme.
 #' @param digits Decides the number of decimal digits to be displayed (Default:
 #'   `2`).
 #' @param as.is A logical passed to \code{\link[reshape2]{melt.array}}. If
@@ -151,7 +152,7 @@ ggcorrplot <- function(corr,
                        pch.col = "black",
                        pch.cex = 5,
                        tl.cex = 12,
-                       tl.col = "black",
+                       tl.col = NULL,
                        tl.srt = 45,
                        digits = 2,
                        as.is = FALSE) {
@@ -269,9 +270,10 @@ ggcorrplot <- function(corr,
         angle = tl.srt,
         vjust = 1,
         size = tl.cex,
-        hjust = 1
+        hjust = 1,
+        colour = tl.col
       ),
-      axis.text.y = ggplot2::element_text(size = tl.cex)
+      axis.text.y = ggplot2::element_text(size = tl.cex, colour = tl.col)
     ) +
     ggplot2::coord_fixed()
 

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -28,7 +28,7 @@ ggcorrplot(
   pch.col = "black",
   pch.cex = 5,
   tl.cex = 12,
-  tl.col = "black",
+  tl.col = NULL,
   tl.srt = 45,
   digits = 2,
   as.is = FALSE
@@ -94,7 +94,8 @@ coefficients (only valid when insig is "pch"). Default value is 4.}
 insig is "pch").}
 
 \item{tl.cex, tl.col, tl.srt}{the size, the color and the string rotation of
-text label (variable names).}
+text label (variable names). \code{tl.col} defaults to \code{NULL}, which
+inherits the color from the theme.}
 
 \item{digits}{Decides the number of decimal digits to be displayed (Default:
 `2`).}

--- a/tests/testthat/test-tl-col.R
+++ b/tests/testthat/test-tl-col.R
@@ -1,0 +1,15 @@
+# Regression tests for the tl.col argument (#44)
+
+test_that("tl.col colours the axis text on both axes (#44)", {
+  corr <- round(cor(mtcars), 1)
+  g <- ggcorrplot(corr, tl.col = "red")
+  expect_equal(ggplot2::calc_element("axis.text.x", g$theme)$colour, "red")
+  expect_equal(ggplot2::calc_element("axis.text.y", g$theme)$colour, "red")
+})
+
+test_that("tl.col defaults to inheriting the theme colour, not a forced black (#44 no-regression)", {
+  corr <- round(cor(mtcars), 1)
+  default_col <- ggplot2::calc_element("axis.text.x", ggcorrplot(corr)$theme)$colour
+  theme_col   <- ggplot2::calc_element("axis.text", ggplot2::theme_minimal())$colour
+  expect_equal(default_col, theme_col)
+})


### PR DESCRIPTION
`tl.col` (the color of the axis text labels) was documented but never passed to the theme, so it had no effect. This wires it into the `axis.text.x`/`axis.text.y` theme elements and changes its default to `NULL`, which inherits the color from the theme — so the **default appearance is byte-identical** (verified: default `ggplot_build()` identical to master; axis-text colour `#4D4D4D` in both), while an explicit `tl.col` is now applied to both axes.

Implemented without a new dependency (no `ggtext`). Credit to @LafontRapnouilTristan for the report and PR #45.

Fixes #44.