### PR TITLE
Add nsmall (label decimals) and legend.limit (fill scale range) arguments (#43, #54)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## New features
 
+- New argument `nsmall` to set a minimum number of decimals in the coefficient
+  labels (e.g. `nsmall = 2` keeps trailing zeros such as 0.70). Defaults to `0`,
+  the current behavior (#43; label-formatting idiom suggested by @PawelKulawiak in #15).
+
+- New argument `legend.limit` to control the limits of the fill color scale.
+  Defaults to `c(-1, 1)`; set `legend.limit = NULL` to use the data range, e.g.
+  to display a covariance matrix (#54).
+
 ## Minor changes
   
 - New argument `as.is` added. A logical passed to melt.array. If TRUE, dimnames

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -48,6 +48,13 @@
 #' @param as.is A logical passed to \code{\link[reshape2]{melt.array}}. If
 #'   \code{TRUE}, dimnames will be left as strings instead of being converted
 #'   using \code{\link[utils]{type.convert}}.
+#' @param nsmall the minimum number of digits to the right of the decimal point
+#'   in the coefficient labels, passed to \code{\link[base]{format}}. Default is
+#'   `0` (no minimum, current behavior). Set e.g. `nsmall = 2` to keep trailing
+#'   zeros (such as 0.70). Only used when \code{lab = TRUE}.
+#' @param legend.limit a length-2 numeric vector giving the limits of the fill
+#'   color scale. Default `c(-1, 1)` (suitable for a correlation matrix); set to
+#'   \code{NULL} to use the data range instead, e.g. for a covariance matrix.
 #' @return \itemize{ \item ggcorrplot(): Returns a ggplot2 \item cor_pmat():
 #' Returns a matrix containing the p-values of correlations }
 #' @examples
@@ -155,7 +162,9 @@ ggcorrplot <- function(corr,
                        tl.col = NULL,
                        tl.srt = 45,
                        digits = 2,
-                       as.is = FALSE) {
+                       as.is = FALSE,
+                       nsmall = 0L,
+                       legend.limit = c(-1, 1)) {
   type <- match.arg(type)
   method <- match.arg(method)
   insig <- match.arg(insig)
@@ -251,7 +260,7 @@ ggcorrplot <- function(corr,
     high = colors[3],
     mid = colors[2],
     midpoint = 0,
-    limit = c(-1, 1),
+    limit = legend.limit,
     space = "Lab",
     name = legend.title
   )
@@ -278,6 +287,7 @@ ggcorrplot <- function(corr,
     ggplot2::coord_fixed()
 
   label <- round(x = corr[, "value"], digits = digits)
+  if (nsmall > 0) label <- format(label, nsmall = nsmall, trim = TRUE)
   if (!is.null(p.mat) & insig == "blank") {
     ns <- corr$pvalue > sig.level
     if (sum(ns) > 0) label[ns] <- " "

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -50,11 +50,11 @@
 #'   using \code{\link[utils]{type.convert}}.
 #' @param nsmall the minimum number of digits to the right of the decimal point
 #'   in the coefficient labels, passed to \code{\link[base]{format}}. Default is
-#'   `0` (no minimum, current behavior). Set e.g. `nsmall = 2` to keep trailing
-#'   zeros (such as 0.70). Only used when \code{lab = TRUE}.
+#'   \code{0} (no minimum, current behavior). Set e.g. \code{nsmall = 2} to keep
+#'   trailing zeros (such as 0.70). Only used when \code{lab = TRUE}.
 #' @param legend.limit a length-2 numeric vector giving the limits of the fill
-#'   color scale. Default `c(-1, 1)` (suitable for a correlation matrix); set to
-#'   \code{NULL} to use the data range instead, e.g. for a covariance matrix.
+#'   color scale. Default \code{c(-1, 1)} (suitable for a correlation matrix); set
+#'   to \code{NULL} to use the data range instead, e.g. for a covariance matrix.
 #' @return \itemize{ \item ggcorrplot(): Returns a ggplot2 \item cor_pmat():
 #' Returns a matrix containing the p-values of correlations }
 #' @examples

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -31,7 +31,9 @@ ggcorrplot(
   tl.col = NULL,
   tl.srt = 45,
   digits = 2,
-  as.is = FALSE
+  as.is = FALSE,
+  nsmall = 0L,
+  legend.limit = c(-1, 1)
 )
 
 cor_pmat(x, ...)
@@ -103,6 +105,15 @@ inherits the color from the theme.}
 \item{as.is}{A logical passed to \code{\link[reshape2]{melt.array}}. If
 \code{TRUE}, dimnames will be left as strings instead of being converted
 using \code{\link[utils]{type.convert}}.}
+
+\item{nsmall}{the minimum number of digits to the right of the decimal point
+in the coefficient labels, passed to \code{\link[base]{format}}. Default is
+\code{0} (no minimum, current behavior). Set e.g. \code{nsmall = 2} to keep
+trailing zeros (such as 0.70). Only used when \code{lab = TRUE}.}
+
+\item{legend.limit}{a length-2 numeric vector giving the limits of the fill
+color scale. Default \code{c(-1, 1)} (suitable for a correlation matrix); set
+to \code{NULL} to use the data range instead, e.g. for a covariance matrix.}
 
 \item{x}{numeric matrix or data frame}
 

--- a/tests/testthat/test-args.R
+++ b/tests/testthat/test-args.R
@@ -1,0 +1,29 @@
+# Tests for the nsmall (#43) and legend.limit (#54) arguments
+
+.text_labels <- function(g) {
+  i <- which(vapply(g$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))
+  g$layers[[i[1]]]$aes_params$label
+}
+
+test_that("nsmall keeps trailing zeros in labels; default is unchanged (#43)", {
+  corr <- round(cor(mtcars), 1)
+  d0 <- .text_labels(ggcorrplot(corr, lab = TRUE))              # default nsmall = 0
+  d2 <- .text_labels(ggcorrplot(corr, lab = TRUE, nsmall = 2))  # two decimals
+  # nsmall = 2 formats to exactly two decimals (e.g. 0.70, 1.00)
+  expect_type(d2, "character")
+  expect_true(all(grepl("^-?[0-9]+\\.[0-9]{2}$", d2)))
+  expect_true(any(d2 %in% c("1.00", "0.70", "-0.70", "-0.90")))
+  # default keeps the plain rounded values (no forced trailing zeros)
+  expect_false(any(as.character(d0) %in% c("1.00", "0.70")))
+})
+
+test_that("legend.limit controls the fill scale range; default is unchanged (#54)", {
+  cv <- cov(mtcars)
+  grey <- function(...) {
+    sum(ggplot2::ggplot_build(ggcorrplot(cv, ...))$data[[1]]$fill == "grey50")
+  }
+  # default limit c(-1, 1) clips covariance values out of range -> grey cells
+  expect_gt(grey(), 0)
+  # NULL uses the data range -> nothing clipped
+  expect_equal(grey(legend.limit = NULL), 0L)
+})


### PR DESCRIPTION
Two additive, opt-in arguments; both default to the current behavior.

**#43 `nsmall`** — minimum number of decimals in the coefficient labels. Default `0` (current behavior, byte-identical); `nsmall = 2` keeps trailing zeros (e.g. 0.70).

**#54 `legend.limit`** — limits of the fill color scale. Default `c(-1, 1)` (byte-identical); `legend.limit = NULL` uses the data range, so a covariance matrix renders instead of clipping out-of-range cells to grey (68 → 0 clipped cells for `cov(mtcars)`).

Default output is byte-identical (verified: `ggplot_build()` battery identical to master). Adds tests. Label-formatting idiom suggested by @PawelKulawiak (#15).

Fixes #43. Fixes #54.