### PR TITLE
Cluster on the unrounded matrix when hc.order = TRUE (#14)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,11 @@
 
 ## Bug fixes
 
+- When `hc.order = TRUE`, the hierarchical clustering is now computed on the
+  unrounded correlation matrix. Previously the matrix was rounded to `digits`
+  before clustering, so the internal rounding could introduce ties that changed
+  the ordering (@buddha2490, #14).
+
 - The `tl.col` argument (color of the axis text labels) is now applied; it was
   previously ignored. It defaults to `NULL`, inheriting the color from the theme,
   so the default appearance is unchanged (@LafontRapnouilTristan, #44, #45).

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -188,8 +188,8 @@ ggcorrplot <- function(corr,
   }
   corr <- as.matrix(corr)
 
-  corr <- base::round(x = corr, digits = digits)
-
+  # Order on the unrounded matrix so the internal rounding below does not
+  # introduce ties that perturb the hierarchical clustering (#14).
   if (hc.order) {
     ord <- .hc_cormat_order(corr, hc.method = hc.method)
     corr <- corr[ord, ord]
@@ -197,6 +197,8 @@ ggcorrplot <- function(corr,
       p.mat <- p.mat[ord, ord]
     }
   }
+
+  corr <- base::round(x = corr, digits = digits)
 
   if (!show.diag) {
     corr <- .remove_diag(corr)

--- a/tests/testthat/test-hc-order.R
+++ b/tests/testthat/test-hc-order.R
@@ -1,0 +1,23 @@
+# Regression test for hc.order clustering on the unrounded matrix (#14)
+
+test_that("hc.order clusters on the unrounded matrix, not the rounded one (#14)", {
+  m <- structure(
+    c(1, 0.6063, 0.1987, 0.2749, -0.2482, 0.231,
+      0.6063, 1, -0.0788, 0.2389, -0.0252, 0.4772,
+      0.1987, -0.0788, 1, 0.7596, 0.3316, -0.445,
+      0.2749, 0.2389, 0.7596, 1, 0.8052, 0.5687,
+      -0.2482, -0.0252, 0.3316, 0.8052, 1, -0.144,
+      0.231, 0.4772, -0.445, 0.5687, -0.144, 1),
+    dim = c(6L, 6L),
+    dimnames = list(LETTERS[1:6], LETTERS[1:6])
+  )
+  ord_of <- function(x) stats::hclust(stats::as.dist((1 - x) / 2), method = "complete")$order
+
+  # For this matrix, rounding to 1 digit changes the clustering order.
+  expect_false(identical(ord_of(m), ord_of(round(m, 1))))
+
+  # ggcorrplot() must order by the UNROUNDED matrix even with an aggressive
+  # digits setting (previously it rounded first, so digits perturbed the order).
+  g <- ggcorrplot(m, hc.order = TRUE, digits = 1)
+  expect_equal(levels(g$data$Var1), rownames(m)[ord_of(m)])
+})


### PR DESCRIPTION
When `hc.order = TRUE`, ggcorrplot rounded the correlation matrix to `digits` **before** clustering, so the internal rounding could introduce ties that perturbed the hierarchical-clustering order. This moves the internal `round()` to **after** the reordering, so clustering uses the unrounded matrix.

Rounding is elementwise, so the displayed (rounded) values are unchanged for a given order; `hc.order = FALSE` output is byte-identical (verified), and only the cluster order changes, and only for tie-prone inputs. Adds a regression test with a matrix where rounding demonstrably changes the order.

Fixes #14.