### PR TITLE
Match p-values to correlation cells by name, not row position

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,10 @@
 
 ## Bug fixes
 
+- The significance markers no longer error or misalign when the correlation
+  matrix and the p-value matrix have different missing-value patterns. P-values
+  are now matched to each cell by name instead of by row position.
+
 - When `hc.order = TRUE`, the hierarchical clustering is now computed on the
   unrounded correlation matrix. Previously the matrix was rounded to `digits`
   before clustering, so the internal rounding could introduce ties that changed

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -222,9 +222,18 @@ ggcorrplot <- function(corr,
 
   if (!is.null(p.mat)) {
     p.mat <- reshape2::melt(p.mat, na.rm = TRUE, as.is = as.is)
+    colnames(p.mat) <- c("Var1", "Var2", "value")
+    # Match each p-value to its correlation cell by (Var1, Var2) rather than by
+    # row position, so a differing NA pattern between corr and p.mat cannot
+    # misalign them (or raise a length error). When the patterns match, the
+    # match is the identity and the result is byte-identical.
+    idx <- match(
+      paste(corr$Var1, corr$Var2, sep = "\r"),
+      paste(p.mat$Var1, p.mat$Var2, sep = "\r")
+    )
     corr$coef <- corr$value
-    corr$pvalue <- p.mat$value
-    corr$signif <- as.numeric(p.mat$value <= sig.level)
+    corr$pvalue <- p.mat$value[idx]
+    corr$signif <- as.numeric(corr$pvalue <= sig.level)
     p.mat <- subset(p.mat, p.mat$value > sig.level)
     if (insig == "blank") {
       corr$value <- corr$value * corr$signif

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -235,8 +235,13 @@ ggcorrplot <- function(corr,
     corr$pvalue <- p.mat$value[idx]
     corr$signif <- as.numeric(corr$pvalue <= sig.level)
     p.mat <- subset(p.mat, p.mat$value > sig.level)
+    # keep significance markers only for cells present in the correlation plot
+    p.mat <- p.mat[paste(p.mat$Var1, p.mat$Var2, sep = "\r") %in%
+      paste(corr$Var1, corr$Var2, sep = "\r"), ]
     if (insig == "blank") {
-      corr$value <- corr$value * corr$signif
+      # a cell with no matching p-value (unknown significance) is kept as-is
+      keep <- ifelse(is.na(corr$signif), 1, corr$signif)
+      corr$value <- corr$value * keep
     }
   }
 
@@ -301,6 +306,7 @@ ggcorrplot <- function(corr,
   if (nsmall > 0) label <- format(label, nsmall = nsmall, trim = TRUE)
   if (!is.null(p.mat) & insig == "blank") {
     ns <- corr$pvalue > sig.level
+    ns[is.na(ns)] <- FALSE
     if (sum(ns) > 0) label[ns] <- " "
   }
 

--- a/tests/testthat/test-pmat.R
+++ b/tests/testthat/test-pmat.R
@@ -37,6 +37,9 @@ test_that("p-values stay aligned when corr and p.mat NA patterns differ", {
   p4["mpg", "disp"] <- p4["disp", "mpg"] <- NA
   # previously this raised "replacement has 14 rows, data has 16"
   expect_no_error(ggcorrplot(c4, p.mat = p4, insig = "pch"))
+  # blank mode must not error either (unknown-significance cells are kept)
+  expect_no_error(ggcorrplot(c4, p.mat = p4, insig = "blank"))
+  expect_no_error(ggcorrplot(c4, p.mat = p4, insig = "blank", lab = TRUE))
 })
 
 test_that("significance markers are matched to cells by name, not position", {

--- a/tests/testthat/test-pmat.R
+++ b/tests/testthat/test-pmat.R
@@ -30,6 +30,25 @@ test_that("hc.order leaves significance unchanged for non-boundary p (#25 no-reg
   )
 })
 
+test_that("p-values stay aligned when corr and p.mat NA patterns differ", {
+  c4 <- round(cor(mtcars[, 1:4]), 2)
+  p4 <- cor_pmat(mtcars[, 1:4])
+  # remove one pair from the p-value matrix only -> different NA pattern
+  p4["mpg", "disp"] <- p4["disp", "mpg"] <- NA
+  # previously this raised "replacement has 14 rows, data has 16"
+  expect_no_error(ggcorrplot(c4, p.mat = p4, insig = "pch"))
+})
+
+test_that("significance markers are matched to cells by name, not position", {
+  m <- matrix(c(1, 0.9, 0.2, 0.9, 1, 0.1, 0.2, 0.1, 1), 3,
+              dimnames = list(c("a", "b", "c"), c("a", "b", "c")))
+  # only the a~c pair is non-significant
+  p <- matrix(c(0, 0.001, 0.6, 0.001, 0, 0.002, 0.6, 0.002, 0), 3,
+              dimnames = list(c("a", "b", "c"), c("a", "b", "c")))
+  cross <- .n_crosses(ggcorrplot(m, p.mat = p, insig = "pch"))
+  expect_equal(cross, 2L)   # exactly a~c and c~a
+})
+
 test_that("p.mat aligns with numeric-looking names when as.is = TRUE (#37)", {
   nm <- c("10", "2", "33")
   m  <- matrix(c(1, 0.8, 0.2, 0.8, 1, 0.1, 0.2, 0.1, 1), 3, dimnames = list(nm, nm))


### PR DESCRIPTION
The p-value matrix was joined to the correlation cells **positionally** (`corr$pvalue <- p.mat$value`). When `corr` and `p.mat` have different missing-value patterns, `reshape2::melt(na.rm=TRUE)` drops different rows, so the assignment errored (`replacement has 14 rows, data has 16`) or silently misaligned the significance markers.

This matches each p-value to its cell by `(Var1, Var2)`. When the NA patterns match, the match is the identity, so output is **byte-identical** (verified across a p.mat battery); when they differ, p-values stay aligned and cells without a p-value get `NA` (no marker). Adds regression tests (the mismatched case that used to error; a name-vs-position alignment check).

This hardens the pre-existing join flagged during the #37 review.