### PR TITLE
Clear error for non-square matrices with hc.order or triangular layouts (#5, #10)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,11 @@
 
 ## Bug fixes
 
+- A non-square (m x n) correlation matrix now gives a clear error when combined
+  with `hc.order = TRUE` or `type = "lower"`/`"upper"` (which require a square
+  matrix), instead of silently producing an incorrect plot. `type = "full"`
+  still works for non-square matrices (#5, #10).
+
 - The significance markers no longer error or misalign when the correlation
   matrix and the p-value matrix have different missing-value patterns. P-values
   are now matched to each cell by name instead of by row position.

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -188,6 +188,18 @@ ggcorrplot <- function(corr,
   }
   corr <- as.matrix(corr)
 
+  # Reordering and the triangular layouts require a square matrix; a non-square
+  # (m x n) correlation matrix can only be shown in full (#5, #10).
+  if (nrow(corr) != ncol(corr)) {
+    if (hc.order) {
+      stop("hc.order = TRUE requires a square correlation matrix.")
+    }
+    if (type != "full") {
+      stop("type = '", type, "' requires a square correlation matrix; ",
+           "use type = 'full' for a non-square matrix.")
+    }
+  }
+
   # Order on the unrounded matrix so the internal rounding below does not
   # introduce ties that perturb the hierarchical clustering (#14).
   if (hc.order) {

--- a/tests/testthat/test-nonsquare.R
+++ b/tests/testthat/test-nonsquare.R
@@ -1,0 +1,18 @@
+# Non-square correlation matrix handling (#5, #10)
+
+test_that("non-square matrix plots in full but errors for clustered/triangular layouts", {
+  rect <- cor(mtcars[, 1:3], mtcars[, 4:7])   # 3 x 4
+
+  # type = "full" (the default) works for a non-square matrix
+  expect_no_error(ggplot2::ggplot_build(ggcorrplot(rect)))
+
+  # hc.order and the triangular layouts require a square matrix -> clear error
+  expect_error(ggcorrplot(rect, hc.order = TRUE), "square")
+  expect_error(ggcorrplot(rect, type = "lower"), "square")
+  expect_error(ggcorrplot(rect, type = "upper"), "square")
+})
+
+test_that("square matrices are unaffected by the non-square guard", {
+  sq <- round(cor(mtcars), 1)
+  expect_no_error(ggplot2::ggplot_build(ggcorrplot(sq, hc.order = TRUE, type = "lower")))
+})


### PR DESCRIPTION
A non-square (m x n) correlation matrix — e.g. `cor(x, y)` — plots fine with the default `type = "full"`, but `hc.order = TRUE` (clustering needs a square matrix) and `type = "lower"/"upper"` (triangular layouts need a square matrix) previously **silently produced an incorrect plot** (with only an internal `as.dist` "matrix not square" warning).

This adds an explicit check that raises a clear error for those combinations, while `type = "full"` continues to work for non-square matrices. Square matrices are unaffected (verified byte-identical). Adds tests.

Fixes #5. Refs #10.