### PR TITLE
Add circle.scale argument to scale circle sizes (#8)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## New features
 
+- New argument `circle.scale` to scale the circle sizes when `method = "circle"`,
+  useful when the output device size makes the default circles too small or too
+  large. Defaults to `1` (contributed by @jdeut, #8).
+
 - New argument `nsmall` to set a minimum number of decimals in the coefficient
   labels (e.g. `nsmall = 2` keeps trailing zeros such as 0.70). Defaults to `0`,
   the current behavior (#43; label-formatting idiom suggested by @PawelKulawiak in #15).

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -55,6 +55,11 @@
 #' @param legend.limit a length-2 numeric vector giving the limits of the fill
 #'   color scale. Default \code{c(-1, 1)} (suitable for a correlation matrix); set
 #'   to \code{NULL} to use the data range instead, e.g. for a covariance matrix.
+#' @param circle.scale a scaling factor for the circle sizes when
+#'   \code{method = "circle"}. Default is \code{1}; increase it (e.g.
+#'   \code{circle.scale = 2}) for larger circles or decrease it for smaller ones,
+#'   which is useful when the output device size makes the default circles too
+#'   small or too large. Has no effect when \code{method = "square"}.
 #' @return \itemize{ \item ggcorrplot(): Returns a ggplot2 \item cor_pmat():
 #' Returns a matrix containing the p-values of correlations }
 #' @examples
@@ -164,7 +169,8 @@ ggcorrplot <- function(corr,
                        digits = 2,
                        as.is = FALSE,
                        nsmall = 0L,
-                       legend.limit = c(-1, 1)) {
+                       legend.limit = c(-1, 1),
+                       circle.scale = 1) {
   type <- match.arg(type)
   method <- match.arg(method)
   insig <- match.arg(insig)
@@ -278,7 +284,7 @@ ggcorrplot <- function(corr,
         shape = 21,
         ggplot2::aes(size = .data[["abs_corr"]])
       ) +
-      ggplot2::scale_size(range = c(4, 10)) +
+      ggplot2::scale_size(range = c(4, 10) * circle.scale) +
       ggplot2::guides(size = "none")
   }
 

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -33,7 +33,8 @@ ggcorrplot(
   digits = 2,
   as.is = FALSE,
   nsmall = 0L,
-  legend.limit = c(-1, 1)
+  legend.limit = c(-1, 1),
+  circle.scale = 1
 )
 
 cor_pmat(x, ...)
@@ -114,6 +115,12 @@ trailing zeros (such as 0.70). Only used when \code{lab = TRUE}.}
 \item{legend.limit}{a length-2 numeric vector giving the limits of the fill
 color scale. Default \code{c(-1, 1)} (suitable for a correlation matrix); set
 to \code{NULL} to use the data range instead, e.g. for a covariance matrix.}
+
+\item{circle.scale}{a scaling factor for the circle sizes when
+\code{method = "circle"}. Default is \code{1}; increase it (e.g.
+\code{circle.scale = 2}) for larger circles or decrease it for smaller ones,
+which is useful when the output device size makes the default circles too
+small or too large. Has no effect when \code{method = "square"}.}
 
 \item{x}{numeric matrix or data frame}
 

--- a/tests/testthat/test-circle-scale.R
+++ b/tests/testthat/test-circle-scale.R
@@ -1,0 +1,20 @@
+# Tests for the circle.scale argument (#8)
+
+test_that("circle.scale scales the circle sizes; default is unchanged (#8)", {
+  corr <- round(cor(mtcars), 1)
+  size_range <- function(cs) {
+    b <- ggplot2::ggplot_build(ggcorrplot(corr, method = "circle", circle.scale = cs))$data
+    pts <- Filter(function(d) "size" %in% names(d) && nrow(d) > 0 && all(d$shape == 21), b)
+    range(pts[[1]]$size)
+  }
+  # default range is c(4, 10); circle.scale multiplies it uniformly
+  expect_equal(size_range(1), c(4, 10))
+  expect_equal(size_range(2), c(8, 20))
+})
+
+test_that("circle.scale has no effect on method = 'square' (#8)", {
+  corr <- round(cor(mtcars), 1)
+  b1 <- ggplot2::ggplot_build(ggcorrplot(corr, circle.scale = 1))$data
+  b3 <- ggplot2::ggplot_build(ggcorrplot(corr, circle.scale = 3))$data
+  expect_identical(b1, b3)
+})


### PR DESCRIPTION
Adds `circle.scale` (default `1`) to scale the circle sizes when `method = "circle"`, by scaling the `scale_size()` range uniformly. This is useful when the output device size makes the default circles too small or too large.

Default output is **byte-identical** for both `method = "square"` and `method = "circle"` (verified); `circle.scale` has no effect on `method = "square"`. At `circle.scale = 2` the point-size range goes from `c(4, 10)` to `c(8, 20)`. Adds tests.

Based on the contribution by @jdeut in #8.