### PR TITLE
Add sig.stars to show significance stars on coefficient labels (#26, #41, #50)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## New features
 
+- New argument `sig.stars` to append significance stars (`***`, `**`, `*`) to
+  the coefficient labels when `lab = TRUE` and a `p.mat` is supplied, e.g.
+  `"-0.85**"`. Defaults to `FALSE` (#26, #41, #50; inspired by the ggcorrplot2
+  package by @caijun).
+
 - New argument `circle.scale` to scale the circle sizes when `method = "circle"`,
   useful when the output device size makes the default circles too small or too
   large. Defaults to `1` (contributed by @jdeut, #8).

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -28,6 +28,12 @@
 #' @param lab logical value. If TRUE, add correlation coefficient on the plot.
 #' @param lab_col,lab_size size and color to be used for the correlation
 #'   coefficient labels. used when lab = TRUE.
+#' @param sig.stars logical value. If \code{TRUE} and a \code{p.mat} is
+#'   supplied, significance stars are appended to the coefficient labels
+#'   (\code{***} for p < 0.001, \code{**} for p < 0.01, \code{*} for p < 0.05),
+#'   e.g. \code{"-0.85**"}. Only used when \code{lab = TRUE}. Default is
+#'   \code{FALSE}. When \code{TRUE}, significance is shown by the stars and the
+#'   \code{insig = "pch"} markers are not drawn.
 #' @param p.mat matrix of p-value. If NULL, arguments sig.level, insig, pch,
 #'   pch.col, pch.cex is invalid.
 #' @param sig.level significant level, if the p-value in p-mat is bigger than
@@ -157,6 +163,7 @@ ggcorrplot <- function(corr,
                        lab = FALSE,
                        lab_col = "black",
                        lab_size = 4,
+                       sig.stars = FALSE,
                        p.mat = NULL,
                        sig.level = 0.05,
                        insig = c("pch", "blank"),
@@ -322,6 +329,14 @@ ggcorrplot <- function(corr,
 
   label <- round(x = corr[, "value"], digits = digits)
   if (nsmall > 0) label <- format(label, nsmall = nsmall, trim = TRUE)
+  if (sig.stars && !is.null(p.mat)) {
+    stars <- as.character(cut(corr$pvalue,
+      breaks = c(-Inf, 0.001, 0.01, 0.05, Inf),
+      labels = c("***", "**", "*", "")
+    ))
+    stars[is.na(stars)] <- ""
+    label <- paste0(label, stars)
+  }
   if (!is.null(p.mat) & insig == "blank") {
     ns <- corr$pvalue > sig.level
     ns[is.na(ns)] <- FALSE
@@ -340,7 +355,7 @@ ggcorrplot <- function(corr,
   }
 
   # matrix cell glyphs
-  if (!is.null(p.mat) & insig == "pch") {
+  if (!is.null(p.mat) & insig == "pch" & !sig.stars) {
     p <- p + ggplot2::geom_point(
       data = p.mat,
       mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -21,6 +21,7 @@ ggcorrplot(
   lab = FALSE,
   lab_col = "black",
   lab_size = 4,
+  sig.stars = FALSE,
   p.mat = NULL,
   sig.level = 0.05,
   insig = c("pch", "blank"),
@@ -78,6 +79,13 @@ using hclust function.}
 
 \item{lab_col, lab_size}{size and color to be used for the correlation
 coefficient labels. used when lab = TRUE.}
+
+\item{sig.stars}{logical value. If \code{TRUE} and a \code{p.mat} is
+supplied, significance stars are appended to the coefficient labels
+(\code{***} for p < 0.001, \code{**} for p < 0.01, \code{*} for p < 0.05),
+e.g. \code{"-0.85**"}. Only used when \code{lab = TRUE}. Default is
+\code{FALSE}. When \code{TRUE}, significance is shown by the stars and the
+\code{insig = "pch"} markers are not drawn.}
 
 \item{p.mat}{matrix of p-value. If NULL, arguments sig.level, insig, pch,
 pch.col, pch.cex is invalid.}

--- a/tests/testthat/test-sig-stars.R
+++ b/tests/testthat/test-sig-stars.R
@@ -1,0 +1,35 @@
+# Tests for the sig.stars argument (#26, #41, #50)
+
+.text_labels <- function(g) {
+  i <- which(vapply(g$layers, function(l) inherits(l$geom, "GeomText"), logical(1)))
+  g$layers[[i[1]]]$aes_params$label
+}
+.n_crosses <- function(g) {
+  b <- ggplot2::ggplot_build(g)$data
+  sum(vapply(b, function(d) {
+    if ("shape" %in% names(d) && nrow(d) > 0 && all(d$shape == 4)) nrow(d) else 0L
+  }, 0L))
+}
+
+test_that("sig.stars appends significance stars to labels; default off is unchanged (#26, #41)", {
+  corr <- round(cor(mtcars), 1)
+  p <- cor_pmat(mtcars)
+
+  # default: no stars appended
+  d0 <- .text_labels(ggcorrplot(corr, p.mat = p, lab = TRUE))
+  expect_false(any(grepl("[*]", d0)))
+
+  # sig.stars = TRUE: stars on significant cells, bare number on non-significant
+  d1 <- .text_labels(ggcorrplot(corr, p.mat = p, lab = TRUE, sig.stars = TRUE))
+  expect_true(any(grepl("[*]{3}$", d1)))          # p < 0.001
+  expect_true(any(grepl("(?<![*])[*]$", d1, perl = TRUE)))  # single star
+  expect_true(any(grepl("^-?[0-9.]+$", d1)))      # non-significant: bare number
+})
+
+test_that("sig.stars suppresses the insig = 'pch' crosses (#33 stays available by default)", {
+  corr <- round(cor(mtcars), 1)
+  p <- cor_pmat(mtcars)
+  # default (pch) draws crosses; sig.stars conveys significance instead
+  expect_gt(.n_crosses(ggcorrplot(corr, p.mat = p, lab = TRUE)), 0)
+  expect_equal(.n_crosses(ggcorrplot(corr, p.mat = p, lab = TRUE, sig.stars = TRUE)), 0)
+})


### PR DESCRIPTION
Adds a `sig.stars` argument (default `FALSE`). When `TRUE` and a `p.mat` is supplied, significance stars are appended to the coefficient labels shown by `lab = TRUE` — `***` (p < 0.001), `**` (p < 0.01), `*` (p < 0.05), e.g. `"-0.85**"` — giving the familiar "r with stars" layout. Significance is then conveyed by the stars, so the `insig = "pch"` crosses are not drawn.

Default output is **byte-identical** (verified across a battery incl. `p.mat`+`pch`/`blank`); the feature is off by default. Adds tests.

Design chosen after weighing the three related requests: stars *appended to the coefficient* (this) directly matches #26/#41 and the standard Hmisc/apaTables/GGally convention, and marks the *significant* cells (#50). Inspired by the `ggcorrplot2` package by @caijun.

Fixes #26. Fixes #41. Fixes #50.