### PR TITLE
Fix the bogus future Date in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: ggcorrplot
 Title: Visualization of a Correlation Matrix using 'ggplot2'
 Version: 0.1.4.999
-Date: 2029-09-27
+Date: 2026-07-07
 Authors@R: 
     c(person(given = "Alboukadel",
              family = "Kassambara",


### PR DESCRIPTION
`Date:` was `2029-09-27` — a future date, which triggers an `R CMD check --as-cran` NOTE and produced the wrong year fallback in `citation()`. Set it to a current date (to be updated to the release date at submission). Metadata only.