### PR TITLE
Add coord.fixed, lab_fontface, tl.vjust/tl.hjust display options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,18 @@
   Defaults to `c(-1, 1)`; set `legend.limit = NULL` to use the data range, e.g.
   to display a covariance matrix (#54).
 
+- New argument `coord.fixed` (default `TRUE`) to optionally drop the fixed 1:1
+  aspect ratio. Set `coord.fixed = FALSE` to let the cells fill the plotting
+  area, which can look better with many long variable names (#40).
+
+- New argument `lab_fontface` to set the font face (`"plain"`, `"bold"`,
+  `"italic"`, `"bold.italic"`) of the correlation coefficient labels. Defaults
+  to `"plain"`, the current behavior (#15).
+
+- New arguments `tl.vjust` and `tl.hjust` to control the vertical and horizontal
+  justification of the x-axis text labels. Both default to `1`, the current
+  behavior (#56).
+
 ## Minor changes
   
 - New argument `as.is` added. A logical passed to melt.array. If TRUE, dimnames

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -28,6 +28,9 @@
 #' @param lab logical value. If TRUE, add correlation coefficient on the plot.
 #' @param lab_col,lab_size size and color to be used for the correlation
 #'   coefficient labels. used when lab = TRUE.
+#' @param lab_fontface the font face (\code{"plain"}, \code{"bold"},
+#'   \code{"italic"}, \code{"bold.italic"}) for the correlation coefficient
+#'   labels. Default is \code{"plain"}. Used when \code{lab = TRUE}.
 #' @param sig.stars logical value. If \code{TRUE} and a \code{p.mat} is
 #'   supplied, significance stars are appended to the coefficient labels
 #'   (\code{***} for p < 0.001, \code{**} for p < 0.01, \code{*} for p < 0.05),
@@ -49,6 +52,9 @@
 #' @param tl.cex,tl.col,tl.srt the size, the color and the string rotation of
 #'   text label (variable names). \code{tl.col} defaults to \code{NULL}, which
 #'   inherits the color from the theme.
+#' @param tl.vjust,tl.hjust the vertical and horizontal justification of the
+#'   x-axis text labels, passed to \code{\link[ggplot2]{element_text}}. Both
+#'   default to \code{1}; adjust them to reposition the variable-name labels.
 #' @param digits Decides the number of decimal digits to be displayed (Default:
 #'   `2`).
 #' @param as.is A logical passed to \code{\link[reshape2]{melt.array}}. If
@@ -66,6 +72,10 @@
 #'   \code{circle.scale = 2}) for larger circles or decrease it for smaller ones,
 #'   which is useful when the output device size makes the default circles too
 #'   small or too large. Has no effect when \code{method = "square"}.
+#' @param coord.fixed logical value. If \code{TRUE} (default), the plot uses
+#'   \code{\link[ggplot2]{coord_fixed}} so the cells are square. Set to
+#'   \code{FALSE} to let the cells fill the plotting area (a non 1:1 aspect
+#'   ratio), which can look better with many long variable names.
 #' @return \itemize{ \item ggcorrplot(): Returns a ggplot2 \item cor_pmat():
 #' Returns a matrix containing the p-values of correlations }
 #' @examples
@@ -163,6 +173,7 @@ ggcorrplot <- function(corr,
                        lab = FALSE,
                        lab_col = "black",
                        lab_size = 4,
+                       lab_fontface = "plain",
                        sig.stars = FALSE,
                        p.mat = NULL,
                        sig.level = 0.05,
@@ -173,11 +184,14 @@ ggcorrplot <- function(corr,
                        tl.cex = 12,
                        tl.col = NULL,
                        tl.srt = 45,
+                       tl.vjust = 1,
+                       tl.hjust = 1,
                        digits = 2,
                        as.is = FALSE,
                        nsmall = 0L,
                        legend.limit = c(-1, 1),
-                       circle.scale = 1) {
+                       circle.scale = 1,
+                       coord.fixed = TRUE) {
   type <- match.arg(type)
   method <- match.arg(method)
   insig <- match.arg(insig)
@@ -318,14 +332,18 @@ ggcorrplot <- function(corr,
     ggplot2::theme(
       axis.text.x = ggplot2::element_text(
         angle = tl.srt,
-        vjust = 1,
+        vjust = tl.vjust,
         size = tl.cex,
-        hjust = 1,
+        hjust = tl.hjust,
         colour = tl.col
       ),
       axis.text.y = ggplot2::element_text(size = tl.cex, colour = tl.col)
-    ) +
-    ggplot2::coord_fixed()
+    )
+  if (coord.fixed) {
+    p <- p + ggplot2::coord_fixed()
+  } else {
+    p <- p + ggplot2::coord_cartesian()
+  }
 
   label <- round(x = corr[, "value"], digits = digits)
   if (nsmall > 0) label <- format(label, nsmall = nsmall, trim = TRUE)
@@ -350,7 +368,8 @@ ggcorrplot <- function(corr,
         mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),
         label = label,
         color = lab_col,
-        size = lab_size
+        size = lab_size,
+        fontface = lab_fontface
       )
   }
 

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -21,6 +21,7 @@ ggcorrplot(
   lab = FALSE,
   lab_col = "black",
   lab_size = 4,
+  lab_fontface = "plain",
   sig.stars = FALSE,
   p.mat = NULL,
   sig.level = 0.05,
@@ -31,11 +32,14 @@ ggcorrplot(
   tl.cex = 12,
   tl.col = NULL,
   tl.srt = 45,
+  tl.vjust = 1,
+  tl.hjust = 1,
   digits = 2,
   as.is = FALSE,
   nsmall = 0L,
   legend.limit = c(-1, 1),
-  circle.scale = 1
+  circle.scale = 1,
+  coord.fixed = TRUE
 )
 
 cor_pmat(x, ...)
@@ -80,6 +84,10 @@ using hclust function.}
 \item{lab_col, lab_size}{size and color to be used for the correlation
 coefficient labels. used when lab = TRUE.}
 
+\item{lab_fontface}{the font face (\code{"plain"}, \code{"bold"},
+\code{"italic"}, \code{"bold.italic"}) for the correlation coefficient
+labels. Default is \code{"plain"}. Used when \code{lab = TRUE}.}
+
 \item{sig.stars}{logical value. If \code{TRUE} and a \code{p.mat} is
 supplied, significance stars are appended to the coefficient labels
 (\code{***} for p < 0.001, \code{**} for p < 0.01, \code{*} for p < 0.05),
@@ -108,6 +116,10 @@ insig is "pch").}
 text label (variable names). \code{tl.col} defaults to \code{NULL}, which
 inherits the color from the theme.}
 
+\item{tl.vjust, tl.hjust}{the vertical and horizontal justification of the
+x-axis text labels, passed to \code{\link[ggplot2]{element_text}}. Both
+default to \code{1}; adjust them to reposition the variable-name labels.}
+
 \item{digits}{Decides the number of decimal digits to be displayed (Default:
 `2`).}
 
@@ -129,6 +141,11 @@ to \code{NULL} to use the data range instead, e.g. for a covariance matrix.}
 \code{circle.scale = 2}) for larger circles or decrease it for smaller ones,
 which is useful when the output device size makes the default circles too
 small or too large. Has no effect when \code{method = "square"}.}
+
+\item{coord.fixed}{logical value. If \code{TRUE} (default), the plot uses
+\code{\link[ggplot2]{coord_fixed}} so the cells are square. Set to
+\code{FALSE} to let the cells fill the plotting area (a non 1:1 aspect
+ratio), which can look better with many long variable names.}
 
 \item{x}{numeric matrix or data frame}
 

--- a/tests/testthat/test-display-args.R
+++ b/tests/testthat/test-display-args.R
@@ -1,0 +1,42 @@
+test_that("coord.fixed toggles the coordinate system", {
+  corr <- round(cor(mtcars), 1)
+  # default: fixed aspect ratio (ratio == 1)
+  expect_equal(ggcorrplot(corr)$coordinates$ratio, 1)
+  # opt-out: cartesian coord, no fixed ratio
+  expect_null(ggcorrplot(corr, coord.fixed = FALSE)$coordinates$ratio)
+})
+
+test_that("coord.fixed default output matches an unconditional coord_fixed()", {
+  corr <- round(cor(mtcars), 1)
+  d <- ggcorrplot(corr)$coordinates
+  expect_identical(class(d), class(ggplot2::coord_fixed()))
+  expect_identical(d$ratio, ggplot2::coord_fixed()$ratio)
+})
+
+test_that("lab_fontface is applied to the coefficient labels", {
+  corr <- round(cor(mtcars), 1)
+  g <- ggcorrplot(corr, lab = TRUE, lab_fontface = "bold")
+  txt <- g$layers[[which(vapply(
+    g$layers, function(L) inherits(L$geom, "GeomText"), logical(1)
+  ))]]
+  expect_identical(txt$aes_params$fontface, "bold")
+  # default stays "plain"
+  g0 <- ggcorrplot(corr, lab = TRUE)
+  txt0 <- g0$layers[[which(vapply(
+    g0$layers, function(L) inherits(L$geom, "GeomText"), logical(1)
+  ))]]
+  expect_identical(txt0$aes_params$fontface, "plain")
+})
+
+test_that("tl.vjust / tl.hjust set the x-axis text justification", {
+  corr <- round(cor(mtcars), 1)
+  th <- ggplot2::calc_element(
+    "axis.text.x", ggcorrplot(corr, tl.vjust = 0.5, tl.hjust = 0)$theme
+  )
+  expect_equal(th$vjust, 0.5)
+  expect_equal(th$hjust, 0)
+  # defaults are 1 / 1
+  th0 <- ggplot2::calc_element("axis.text.x", ggcorrplot(corr)$theme)
+  expect_equal(th0$vjust, 1)
+  expect_equal(th0$hjust, 1)
+})


### PR DESCRIPTION
Adds three additive display options; all default to the current behavior, so default output is unchanged (verified: rendered plots for the default, circle, lower+lab, pch, blank+lab and hc.order cases are byte-identical).

- **`coord.fixed`** (default `TRUE`) — set `FALSE` to drop the fixed 1:1 aspect ratio and let the cells fill the plotting area, which reads better with many long variable names. Fixes #40.
- **`lab_fontface`** (default `"plain"`) — font face (`"plain"`, `"bold"`, `"italic"`, `"bold.italic"`) for the correlation-coefficient labels when `lab = TRUE`. This answers the bold-label request in #15; that issue also asks for dropping the leading zero (e.g. `.23` instead of `0.23`), which is a separate change, so #15 stays open. Refs #15.
- **`tl.vjust` / `tl.hjust`** (default `1`) — vertical/horizontal justification of the x-axis text labels, for finer control over label placement. Refs #56. Note: #56 is specifically about offsetting the y-axis labels next to the cells on a triangular (`type = "lower"`) plot; these arguments do not cover that, so #56 stays open for a dedicated fix.

New regression tests cover each option and confirm the defaults are unchanged.