### PR TITLE
Let the colors argument accept a palette of any length

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,14 @@
   Defaults to `c(-1, 1)`; set `legend.limit = NULL` to use the data range, e.g.
   to display a covariance matrix (#54).
 
+- The `colors` argument now accepts a vector of any length `>= 2`, not only 3.
+  A length-3 vector still maps to low/mid/high via `scale_fill_gradient2` (default
+  output unchanged); any other length is spread across the scale with
+  `scale_fill_gradientn`, so an n-color palette such as
+  `RColorBrewer::brewer.pal(11, "RdBu")` can be passed straight to `colors =`
+  without adding a second fill scale (and without the "Scale for fill is already
+  present" message) (#52). Requested by @glocke-senda.
+
 - New argument `coord.fixed` (default `TRUE`) to optionally drop the fixed 1:1
   aspect ratio. Set `coord.fixed = FALSE` to let the cells fill the plotting
   area, which can look better with many long variable names (#40).

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -19,7 +19,12 @@
 #'   coefficients on the principal diagonal. If \code{NULL}, the default is to
 #'   show diagonal correlation for \code{type = "full"} and to remove it when
 #'   \code{type} is one of "upper" or "lower".
-#' @param colors a vector of 3 colors for low, mid and high correlation values.
+#' @param colors a vector of colors for the fill gradient. The default is a
+#'   length-3 vector for the low, mid and high correlation values (mapped with
+#'   \code{\link[ggplot2]{scale_fill_gradient2}}). A vector of any other length
+#'   (\code{>= 2}) is spread evenly across the scale with
+#'   \code{\link[ggplot2]{scale_fill_gradientn}}, so an n-color palette (e.g.
+#'   \code{RColorBrewer::brewer.pal(11, "RdBu")}) can be passed directly.
 #' @param outline.color the outline color of square or circle. Default value is
 #'   "gray".
 #' @param hc.order logical value. If TRUE, correlation matrix will be hc.ordered
@@ -310,15 +315,29 @@ ggcorrplot <- function(corr,
   }
 
   # adding colors
-  p <- p + ggplot2::scale_fill_gradient2(
-    low = colors[1],
-    high = colors[3],
-    mid = colors[2],
-    midpoint = 0,
-    limit = legend.limit,
-    space = "Lab",
-    name = legend.title
-  )
+  if (length(colors) < 2) {
+    stop("'colors' must contain at least 2 colors.", call. = FALSE)
+  }
+  if (length(colors) == 3) {
+    p <- p + ggplot2::scale_fill_gradient2(
+      low = colors[1],
+      high = colors[3],
+      mid = colors[2],
+      midpoint = 0,
+      limit = legend.limit,
+      space = "Lab",
+      name = legend.title
+    )
+  } else {
+    # any palette that is not exactly low/mid/high: spread the colors evenly
+    # across the scale with gradientn. Lets users pass e.g. an 11-color
+    # RColorBrewer palette directly, without adding a second fill scale (#52).
+    p <- p + ggplot2::scale_fill_gradientn(
+      colours = colors,
+      limits = legend.limit,
+      name = legend.title
+    )
+  }
 
   # depending on the class of the object, add the specified theme
   if (class(ggtheme)[[1]] == "function") {

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -69,7 +69,12 @@ coefficients on the principal diagonal. If \code{NULL}, the default is to
 show diagonal correlation for \code{type = "full"} and to remove it when
 \code{type} is one of "upper" or "lower".}
 
-\item{colors}{a vector of 3 colors for low, mid and high correlation values.}
+\item{colors}{a vector of colors for the fill gradient. The default is a
+length-3 vector for the low, mid and high correlation values (mapped with
+\code{\link[ggplot2]{scale_fill_gradient2}}). A vector of any other length
+(\code{>= 2}) is spread evenly across the scale with
+\code{\link[ggplot2]{scale_fill_gradientn}}, so an n-color palette (e.g.
+\code{RColorBrewer::brewer.pal(11, "RdBu")}) can be passed directly.}
 
 \item{outline.color}{the outline color of square or circle. Default value is
 "gray".}

--- a/tests/testthat/test-colors-vector.R
+++ b/tests/testthat/test-colors-vector.R
@@ -1,0 +1,60 @@
+fill_scale <- function(g) g$scales$get_scales("fill")
+
+n_fill_scales <- function(g) {
+  sum(vapply(g$scales$scales, function(s) "fill" %in% s$aesthetics, logical(1)))
+}
+
+test_that("the default (length-3) colors still use scale_fill_gradient2", {
+  corr <- round(cor(mtcars), 1)
+  g <- ggcorrplot(corr)
+  expect_equal(n_fill_scales(g), 1L)
+  cl <- fill_scale(g)$call
+  if (!is.null(cl)) {
+    expect_match(paste(deparse(cl), collapse = " "), "gradient2")
+  }
+})
+
+test_that("an explicit length-3 colors vector keeps the gradient2 path", {
+  corr <- round(cor(mtcars), 1)
+  g <- ggcorrplot(corr, colors = c("#6D9EC1", "white", "#E46726"))
+  cl <- fill_scale(g)$call
+  if (!is.null(cl)) {
+    expect_match(paste(deparse(cl), collapse = " "), "gradient2")
+  }
+})
+
+test_that("a colors vector of length != 3 uses gradientn and one fill scale", {
+  corr <- round(cor(mtcars), 1)
+  pal <- c("#67001F", "#D6604D", "#F7F7F7", "#4393C3", "#053061") # length 5
+  g <- ggcorrplot(corr, colors = pal)
+  # exactly one fill scale: the palette is applied without adding a second one
+  expect_equal(n_fill_scales(g), 1L)
+  cl <- fill_scale(g)$call
+  if (!is.null(cl)) {
+    expect_match(paste(deparse(cl), collapse = " "), "gradientn")
+  }
+  # builds without error (a longer palette used to require a manual second scale)
+  expect_silent(ggplot2::ggplot_build(g))
+})
+
+test_that("a length-2 colors vector also works via gradientn", {
+  corr <- round(cor(mtcars), 1)
+  g <- ggcorrplot(corr, colors = c("navy", "gold"))
+  expect_equal(n_fill_scales(g), 1L)
+  cl <- fill_scale(g)$call
+  if (!is.null(cl)) {
+    expect_match(paste(deparse(cl), collapse = " "), "gradientn")
+  }
+})
+
+test_that("fewer than 2 colors gives a clear error", {
+  corr <- round(cor(mtcars), 1)
+  expect_error(ggcorrplot(corr, colors = "red"), "at least 2")
+})
+
+test_that("legend.limit is honored on the gradientn path", {
+  corr <- round(cor(mtcars), 1)
+  pal <- c("#67001F", "#D6604D", "#F7F7F7", "#4393C3", "#053061")
+  g <- ggcorrplot(corr, colors = pal, legend.limit = c(-1, 1))
+  expect_equal(fill_scale(g)$limits, c(-1, 1))
+})


### PR DESCRIPTION
Closes #52. The `colors` argument now accepts a vector of any length `>= 2`, so an n-color palette can be passed directly:

``` r
library(ggcorrplot)
corr <- cor(mtcars)
ggcorrplot(corr, colors = RColorBrewer::brewer.pal(11, "RdBu"))
```

- **Length 3** keeps the current low/mid/high mapping via `scale_fill_gradient2` — default output is unchanged.
- **Any other length** is spread evenly across the scale with `scale_fill_gradientn`. Because the palette is applied by `ggcorrplot()` itself, users no longer need to add a second `+ scale_fill_*()`, which is what produced the `Scale for fill is already present. Adding another scale for fill...` message in #52 (the workaround it links to in #9 is where that extra scale came from).
- **Fewer than 2 colors** now errors clearly instead of failing obscurely.

`legend.limit` is honored on the new path too. Default output for the length-3 case is byte-identical; new regression tests cover the gradient2/gradientn split, the single-fill-scale guarantee, and the error.
