### PR TITLE
cor_pmat: return NA for uncomputable pairs instead of erroring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,12 @@
 
 ## Bug fixes
 
+- `cor_pmat()` no longer aborts when a pair of variables has fewer than three
+  overlapping non-missing observations to correlate (e.g. two variables that
+  never co-occur). Such a pair now returns `NA` for that cell instead of erroring
+  out for the whole matrix; pairs that can be tested are computed as before
+  (@elizabethwe, #51).
+
 - A non-square (m x n) correlation matrix now gives a clear error when combined
   with `hc.order = TRUE` or `type = "lower"`/`"upper"` (which require a square
   matrix), instead of silently producing an incorrect plot. `type = "full"`

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -425,6 +425,13 @@ ggcorrplot <- function(corr,
 
 #' Compute the matrix of correlation p-values
 #'
+#' @details \code{cor_pmat()} tests each pair of columns with
+#'   \code{\link[stats]{cor.test}}. A pair with fewer than three overlapping
+#'   non-missing observations (which \code{\link[stats]{cor.test}} cannot test,
+#'   e.g. two variables that never co-occur) yields \code{NA} for that cell
+#'   rather than aborting the whole computation. Pairs that can be tested are
+#'   computed as before, and errors they raise are passed through.
+#'
 #' @param x numeric matrix or data frame
 #' @param ... other arguments to be passed to the function cor.test.
 #' @rdname ggcorrplot
@@ -441,8 +448,22 @@ cor_pmat <- function(x, ...) {
   # creating the p-value matrix
   for (i in 1:(n - 1)) {
     for (j in (i + 1):n) {
-      tmp <- stats::cor.test(mat[, i], mat[, j], ...)
-      p.mat[i, j] <- p.mat[j, i] <- tmp$p.value
+      # a pair with too few overlapping observations (e.g. two variables that
+      # never co-occur) makes cor.test() error; return NA for that cell instead
+      # of aborting the whole matrix (#51). The NA substitution is gated on the
+      # overlap count, so for any pair that CAN be tested (>= 3 overlapping obs)
+      # a genuine error (bad method =, non-numeric input, ...) is re-raised and
+      # still surfaces loudly instead of silently becoming NA.
+      p.mat[i, j] <- p.mat[j, i] <- tryCatch(
+        stats::cor.test(mat[, i], mat[, j], ...)$p.value,
+        error = function(e) {
+          if (sum(stats::complete.cases(mat[, i], mat[, j])) < 3) {
+            NA_real_
+          } else {
+            stop(e)
+          }
+        }
+      )
     }
   }
 

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -160,6 +160,14 @@ ratio), which can look better with many long variable names.}
 \itemize{ \item ggcorrplot(): Returns a ggplot2 \item cor_pmat():
 Returns a matrix containing the p-values of correlations }
 }
+\details{
+\code{cor_pmat()} tests each pair of columns with
+\code{\link[stats]{cor.test}}. A pair with fewer than three overlapping
+non-missing observations (which \code{\link[stats]{cor.test}} cannot test,
+e.g. two variables that never co-occur) yields \code{NA} for that cell
+rather than aborting the whole computation. Pairs that can be tested are
+computed as before, and errors they raise are passed through.
+}
 \description{
 \itemize{ \item ggcorrplot(): A graphical display of a
   correlation matrix using ggplot2. \item cor_pmat(): Compute a correlation

--- a/tests/testthat/test-cor-pmat-na.R
+++ b/tests/testthat/test-cor-pmat-na.R
@@ -1,0 +1,43 @@
+test_that("cor_pmat on complete data is unchanged (no NA, symmetric, zero diag)", {
+  pm <- cor_pmat(mtcars)
+  expect_false(anyNA(pm))
+  expect_equal(diag(pm), rep(0, ncol(mtcars)), ignore_attr = TRUE)
+  expect_equal(pm, t(pm))
+})
+
+test_that("cor_pmat returns NA for an uncomputable pair instead of erroring", {
+  # A and D never co-occur (complementary missingness) -> no overlapping obs
+  d <- data.frame(
+    A = c(1, 2, 3, 4, 5, NA, NA, NA, NA, NA),
+    B = c(2, 4, 6, 8, 10, 1, 2, 3, 4, 5),
+    C = c(5, 3, 6, 2, 8, 1, 9, 4, 7, 0),
+    D = c(NA, NA, NA, NA, NA, 5, 4, 3, 2, 1)
+  )
+  pm <- expect_no_error(cor_pmat(d))
+  expect_true(is.na(pm["A", "D"]))
+  expect_true(is.na(pm["D", "A"]))
+  # computable pairs still get a p-value
+  expect_false(is.na(pm["B", "C"]))
+  # diagonal and symmetry preserved
+  expect_equal(diag(pm), rep(0, 4), ignore_attr = TRUE)
+  expect_equal(pm, t(pm))
+})
+
+test_that("cor_pmat does not swallow genuine errors into NA", {
+  # a bad method= must still error loudly, not silently return an all-NA matrix
+  expect_error(cor_pmat(mtcars, method = "bogus"))
+  # a non-numeric column must still error, not become NA
+  dd <- data.frame(a = 1:10, b = letters[1:10], c = rnorm(10))
+  expect_error(cor_pmat(dd))
+})
+
+test_that("cor_pmat still forwards extra args to cor.test", {
+  pearson <- cor_pmat(mtcars)
+  # method = "spearman" is forwarded to cor.test (ties warning is expected on
+  # mtcars and not what we are testing here).
+  spearman <- suppressWarnings(cor_pmat(mtcars, method = "spearman"))
+  expect_false(anyNA(spearman))
+  expect_equal(spearman, t(spearman))
+  # forwarding actually took effect: spearman p-values differ from pearson
+  expect_false(isTRUE(all.equal(pearson, spearman)))
+})


### PR DESCRIPTION
Refs #51. When a pair of variables has fewer than three overlapping non-missing observations to correlate — e.g. two variables that never co-occur — `stats::cor.test()` errors ("not enough finite observations"), which previously aborted the whole `cor_pmat()` call. That pair now returns `NA` for its cell, so the rest of the matrix is still computed.

``` r
library(ggcorrplot)
d <- data.frame(
  A = c(1, 2, 3, 4, 5, NA, NA, NA, NA, NA),
  B = c(2, 4, 6, 8, 10, 1, 2, 3, 4, 5),
  C = c(5, 3, 6, 2, 8, 1, 9, 4, 7, 0),
  D = c(NA, NA, NA, NA, NA, 5, 4, 3, 2, 1)   # never co-occurs with A
)
cor_pmat(d)   # the A/D cell is NA instead of crashing the whole call
```

Scope and safety:
- The `NA` substitution is gated on the overlap count: only a pair with fewer than three overlapping observations becomes `NA`. Pairs that can be tested are computed exactly as before, so a genuine error they raise (a non-numeric column, an invalid `method =`, ...) still surfaces from `cor.test()` rather than being hidden.
- Output is byte-identical for complete data (verified on `mtcars`, `iris`, and `method = "spearman"`).

Not auto-closing #51: this fixes the case where the pair is genuinely uncomputable (cor.test errors). If the reporter's `NA`s instead come from `cor(use = "everything")` on columns that *do* overlap, `cor_pmat()` still computes a valid pairwise p-value for those pairs — a separate matter — so I want to confirm their exact case before closing.

New regression tests cover the NA case, that computable pairs still surface real errors, and that complete-data output is unchanged.
