### PR TITLE
cor_pmat: add a use argument to align the NA pattern with cor()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,12 @@
   justification of the x-axis text labels. Both default to `1`, the current
   behavior (#56).
 
+- New argument `use` in `cor_pmat()` to align the p-value matrix's `NA` pattern
+  with a correlation matrix. The default `"pairwise.complete.obs"` keeps the
+  current behavior; `use = "everything"` sets a pair to `NA` as soon as either
+  variable has a missing value, matching `cor()`'s default so the two matrices
+  line up (@elizabethwe, #51).
+
 ## Minor changes
   
 - New argument `as.is` added. A logical passed to melt.array. If TRUE, dimnames

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -432,12 +432,28 @@ ggcorrplot <- function(corr,
 #'   rather than aborting the whole computation. Pairs that can be tested are
 #'   computed as before, and errors they raise are passed through.
 #'
+#'   The \code{use} argument controls which pairs are returned as \code{NA} so
+#'   the p-value matrix can be aligned with a correlation matrix built the same
+#'   way. With the default \code{"pairwise.complete.obs"} every pair that has
+#'   enough overlapping observations is tested (the previous behavior). With
+#'   \code{"everything"} a pair is set to \code{NA} whenever either variable has
+#'   any missing value, so the \code{NA} pattern matches
+#'   \code{\link[stats]{cor}(x)} with its default \code{use = "everything"}.
+#'
 #' @param x numeric matrix or data frame
 #' @param ... other arguments to be passed to the function cor.test.
+#' @param use character, how to treat pairs involving missing values when
+#'   deciding which cells are \code{NA}. Either \code{"pairwise.complete.obs"}
+#'   (default; test every pair that has enough overlapping observations) or
+#'   \code{"everything"} (set a pair to \code{NA} as soon as either variable has
+#'   a missing value, matching \code{\link[stats]{cor}}'s default). Mirrors the
+#'   corresponding values of \code{\link[stats]{cor}}'s \code{use} argument.
 #' @rdname ggcorrplot
 #' @export
 
-cor_pmat <- function(x, ...) {
+cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
+
+  use <- match.arg(use)
 
   # initializing values
   mat <- as.matrix(x)
@@ -445,25 +461,36 @@ cor_pmat <- function(x, ...) {
   p.mat <- matrix(NA, n, n)
   diag(p.mat) <- 0
 
+  # Pattern of pairs to leave as NA, taken from cor() under the same `use`, so
+  # the result can be aligned with a cor(x, use = ...) matrix (#51). This is
+  # missingness-driven, so it does not depend on the correlation method passed
+  # through `...`; computing the mask with cor()'s default (pearson) is fine.
+  cor_mask <- stats::cor(mat, use = use)
+
   # creating the p-value matrix
   for (i in 1:(n - 1)) {
     for (j in (i + 1):n) {
-      # a pair with too few overlapping observations (e.g. two variables that
-      # never co-occur) makes cor.test() error; return NA for that cell instead
-      # of aborting the whole matrix (#51). The NA substitution is gated on the
-      # overlap count, so for any pair that CAN be tested (>= 3 overlapping obs)
-      # a genuine error (bad method =, non-numeric input, ...) is re-raised and
-      # still surfaces loudly instead of silently becoming NA.
-      p.mat[i, j] <- p.mat[j, i] <- tryCatch(
-        stats::cor.test(mat[, i], mat[, j], ...)$p.value,
-        error = function(e) {
-          if (sum(stats::complete.cases(mat[, i], mat[, j])) < 3) {
-            NA_real_
-          } else {
-            stop(e)
+      if (is.na(cor_mask[i, j])) {
+        # cor() could not compute this pair under `use`: leave it NA.
+        p.mat[i, j] <- p.mat[j, i] <- NA_real_
+      } else {
+        # a pair with too few overlapping observations (e.g. two variables that
+        # never co-occur) makes cor.test() error; return NA for that cell instead
+        # of aborting the whole matrix (#51). The NA substitution is gated on the
+        # overlap count, so for any pair that CAN be tested (>= 3 overlapping obs)
+        # a genuine error (bad method =, non-numeric input, ...) is re-raised and
+        # still surfaces loudly instead of silently becoming NA.
+        p.mat[i, j] <- p.mat[j, i] <- tryCatch(
+          stats::cor.test(mat[, i], mat[, j], ...)$p.value,
+          error = function(e) {
+            if (sum(stats::complete.cases(mat[, i], mat[, j])) < 3) {
+              NA_real_
+            } else {
+              stop(e)
+            }
           }
-        }
-      )
+        )
+      }
     }
   }
 

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -42,7 +42,7 @@ ggcorrplot(
   coord.fixed = TRUE
 )
 
-cor_pmat(x, ...)
+cor_pmat(x, ..., use = c("pairwise.complete.obs", "everything"))
 }
 \arguments{
 \item{corr}{the correlation matrix to visualize}
@@ -155,6 +155,13 @@ ratio), which can look better with many long variable names.}
 \item{x}{numeric matrix or data frame}
 
 \item{...}{other arguments to be passed to the function cor.test.}
+
+\item{use}{character, how to treat pairs involving missing values when
+deciding which cells are \code{NA}. Either \code{"pairwise.complete.obs"}
+(default; test every pair that has enough overlapping observations) or
+\code{"everything"} (set a pair to \code{NA} as soon as either variable has
+a missing value, matching \code{\link[stats]{cor}}'s default). Mirrors the
+corresponding values of \code{\link[stats]{cor}}'s \code{use} argument.}
 }
 \value{
 \itemize{ \item ggcorrplot(): Returns a ggplot2 \item cor_pmat():
@@ -167,6 +174,14 @@ non-missing observations (which \code{\link[stats]{cor.test}} cannot test,
 e.g. two variables that never co-occur) yields \code{NA} for that cell
 rather than aborting the whole computation. Pairs that can be tested are
 computed as before, and errors they raise are passed through.
+
+The \code{use} argument controls which pairs are returned as \code{NA} so
+the p-value matrix can be aligned with a correlation matrix built the same
+way. With the default \code{"pairwise.complete.obs"} every pair that has
+enough overlapping observations is tested (the previous behavior). With
+\code{"everything"} a pair is set to \code{NA} whenever either variable has
+any missing value, so the \code{NA} pattern matches
+\code{\link[stats]{cor}(x)} with its default \code{use = "everything"}.
 }
 \description{
 \itemize{ \item ggcorrplot(): A graphical display of a

--- a/tests/testthat/test-cor-pmat-use.R
+++ b/tests/testthat/test-cor-pmat-use.R
@@ -1,0 +1,48 @@
+test_that("cor_pmat default use is unchanged (byte-identical)", {
+  # the default 'pairwise.complete.obs' must reproduce the historical output
+  expect_identical(cor_pmat(mtcars), cor_pmat(mtcars, use = "pairwise.complete.obs"))
+  expect_false(anyNA(cor_pmat(mtcars)))
+  # partial-NA but every pair still computable: default must not blank anything new
+  set.seed(1)
+  m <- mtcars
+  m[cbind(sample(32, 6), sample(11, 6))] <- NA
+  pm <- cor_pmat(m)
+  expect_equal(pm, t(pm))
+})
+
+test_that("use = 'everything' aligns the NA pattern with cor()'s default", {
+  d <- data.frame(
+    A = c(1, 2, 3, 4, 5, NA, NA, NA, NA, NA),
+    B = c(2, 4, 6, 8, 10, 1, 2, 3, 4, 5),
+    C = c(5, 3, 6, 2, 8, 1, 9, 4, 7, 0),
+    D = c(NA, NA, NA, NA, NA, 5, 4, 3, 2, 1)
+  )
+  # cor() default is use = "everything": NA wherever a column has any NA
+  expect_identical(is.na(cor_pmat(d, use = "everything")), is.na(cor(d)))
+  # pairs where both columns are complete still get a real p-value
+  expect_false(is.na(cor_pmat(d, use = "everything")["B", "C"]))
+  # symmetric, zero diagonal preserved
+  pm <- cor_pmat(d, use = "everything")
+  expect_equal(pm, t(pm))
+  expect_equal(diag(pm), rep(0, 4), ignore_attr = TRUE)
+})
+
+test_that("use is restricted to the two safe values", {
+  d <- data.frame(a = c(1, 2, 3, NA), b = c(4, 3, 2, 1), c = c(1, 1, 2, 3))
+  # listwise options would make the p-value and the coefficient disagree; rejected
+  expect_error(cor_pmat(d, use = "complete.obs"))
+  expect_error(cor_pmat(d, use = "na.or.complete"))
+  # all.obs would only ever error on NA data; rejected
+  expect_error(cor_pmat(d, use = "all.obs"))
+})
+
+test_that("the uncomputable-pair fix still holds under the default use", {
+  # two variables that never co-occur -> NA, no crash (regression guard for #51/#78)
+  d <- data.frame(
+    A = c(1, 2, 3, 4, 5, NA, NA, NA, NA, NA),
+    B = c(2, 4, 6, 8, 10, 1, 2, 3, 4, 5),
+    D = c(NA, NA, NA, NA, NA, 5, 4, 3, 2, 1)
+  )
+  pm <- expect_no_error(cor_pmat(d))
+  expect_true(is.na(pm["A", "D"]))
+})


### PR DESCRIPTION
Fixes #51. Adds a `use` argument to `cor_pmat()` so its `NA` pattern can be aligned with a correlation matrix.

`cor_pmat()` tests each pair with `cor.test()`, which uses pairwise-complete observations. So for a pair where one variable has a missing value, `cor.test()` still returns a p-value even though `cor()` with its default `use = "everything"` shows `NA` for that cell — which is what @elizabethwe reported (the p-value matrix ends up with more values than the correlation matrix). The new argument lets a user line the two up:

``` r
library(ggcorrplot)
d <- data.frame(
  A = c(1, 2, 3, 4, 5, NA, NA, NA, NA, NA),
  B = c(2, 4, 6, 8, 10, 1, 2, 3, 4, 5),
  C = c(5, 3, 6, 2, 8, 1, 9, 4, 7, 0),
  D = c(NA, NA, NA, NA, NA, 5, 4, 3, 2, 1)
)
cor_pmat(d, use = "everything")   # NA wherever cor(d) is NA
```

- **`"pairwise.complete.obs"`** (default) reproduces the previous behavior exactly — default output is byte-identical (verified on mtcars, iris, USArrests, spearman, and partial-NA data).
- **`"everything"`** sets a pair to `NA` as soon as either variable has a missing value, so `is.na(cor_pmat(d, use = "everything"))` matches `is.na(cor(d))`.

`use` is restricted to those two values with `match.arg`. The listwise options (`"complete.obs"`, `"na.or.complete"`) are deliberately excluded: `cor()` would compute the coefficient on rows complete across *all* columns while `cor.test()` still tests pairwise, so the p-value could disagree with the coefficient the user sees (a perfect `r` could be stamped non-significant). `"all.obs"` is excluded because it only ever errors on data with `NA`s.

New regression tests cover the byte-identical default, the `"everything"` alignment, and the rejection of the unsafe `use` values.
