### PR TITLE
Add leading.zero to drop the leading zero of coefficient labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,11 @@
   `"italic"`, `"bold.italic"`) of the correlation coefficient labels. Defaults
   to `"plain"`, the current behavior (#15).
 
+- New argument `leading.zero` to drop the leading zero of the coefficient labels
+  (e.g. `.23`, `-.67` instead of `0.23`, `-0.67`), common in correlation tables.
+  Defaults to `TRUE` (leading zero kept, current behavior); set
+  `leading.zero = FALSE` to remove it (#15; idiom from @PawelKulawiak's comment).
+
 - New arguments `tl.vjust` and `tl.hjust` to control the vertical and horizontal
   justification of the x-axis text labels. Both default to `1`, the current
   behavior (#56).

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -69,6 +69,10 @@
 #'   in the coefficient labels, passed to \code{\link[base]{format}}. Default is
 #'   \code{0} (no minimum, current behavior). Set e.g. \code{nsmall = 2} to keep
 #'   trailing zeros (such as 0.70). Only used when \code{lab = TRUE}.
+#' @param leading.zero logical. If \code{TRUE} (default), coefficient labels keep
+#'   the leading zero (e.g. \code{0.23}, \code{-0.67}). Set to \code{FALSE} to
+#'   drop it (\code{.23}, \code{-.67}), which is common for correlation tables.
+#'   Only used when \code{lab = TRUE}.
 #' @param legend.limit a length-2 numeric vector giving the limits of the fill
 #'   color scale. Default \code{c(-1, 1)} (suitable for a correlation matrix); set
 #'   to \code{NULL} to use the data range instead, e.g. for a covariance matrix.
@@ -194,6 +198,7 @@ ggcorrplot <- function(corr,
                        digits = 2,
                        as.is = FALSE,
                        nsmall = 0L,
+                       leading.zero = TRUE,
                        legend.limit = c(-1, 1),
                        circle.scale = 1,
                        coord.fixed = TRUE) {
@@ -366,6 +371,11 @@ ggcorrplot <- function(corr,
 
   label <- round(x = corr[, "value"], digits = digits)
   if (nsmall > 0) label <- format(label, nsmall = nsmall, trim = TRUE)
+  if (!leading.zero) {
+    # drop the leading zero of values in (-1, 1), e.g. 0.23 -> .23, -0.67 -> -.67
+    # (idiom from @PawelKulawiak, #15). The \\b keeps values like 1.00 untouched.
+    label <- gsub("\\b0(\\.\\d+)", "\\1", label)
+  }
   if (sig.stars && !is.null(p.mat)) {
     stars <- as.character(cut(corr$pvalue,
       breaks = c(-Inf, 0.001, 0.01, 0.05, Inf),

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -37,6 +37,7 @@ ggcorrplot(
   digits = 2,
   as.is = FALSE,
   nsmall = 0L,
+  leading.zero = TRUE,
   legend.limit = c(-1, 1),
   circle.scale = 1,
   coord.fixed = TRUE
@@ -136,6 +137,11 @@ using \code{\link[utils]{type.convert}}.}
 in the coefficient labels, passed to \code{\link[base]{format}}. Default is
 \code{0} (no minimum, current behavior). Set e.g. \code{nsmall = 2} to keep
 trailing zeros (such as 0.70). Only used when \code{lab = TRUE}.}
+
+\item{leading.zero}{logical. If \code{TRUE} (default), coefficient labels keep
+the leading zero (e.g. \code{0.23}, \code{-0.67}). Set to \code{FALSE} to
+drop it (\code{.23}, \code{-.67}), which is common for correlation tables.
+Only used when \code{lab = TRUE}.}
 
 \item{legend.limit}{a length-2 numeric vector giving the limits of the fill
 color scale. Default \code{c(-1, 1)} (suitable for a correlation matrix); set

--- a/tests/testthat/test-leading-zero.R
+++ b/tests/testthat/test-leading-zero.R
@@ -1,0 +1,43 @@
+text_labels <- function(g) {
+  i <- which(vapply(g$layers, function(L) inherits(L$geom, "GeomText"), logical(1)))
+  g$layers[[i]]$aes_params$label
+}
+
+test_that("leading.zero defaults to keeping the zero (unchanged behavior)", {
+  corr <- round(cor(mtcars), 2)
+  labs <- text_labels(ggcorrplot(corr, lab = TRUE))
+  # at least one label like 0.xx or -0.xx present, none stripped
+  expect_true(any(grepl("^-?0\\.", labs)))
+  expect_false(any(grepl("^-?\\.[0-9]", labs)))
+})
+
+test_that("leading.zero = FALSE drops the leading zero, including negatives", {
+  corr <- round(cor(mtcars), 2)
+  labs <- text_labels(ggcorrplot(corr, lab = TRUE, leading.zero = FALSE))
+  # no label should keep a leading 0 before the decimal
+  expect_false(any(grepl("^-?0\\.", labs)))
+  # values in (-1, 1) now start with . or -.
+  expect_true(any(grepl("^\\.[0-9]", labs)))   # e.g. .68
+  expect_true(any(grepl("^-\\.[0-9]", labs)))  # e.g. -.85
+})
+
+test_that("leading.zero = FALSE leaves 1.00 and integers untouched", {
+  m <- matrix(c(1, -0.67, 0.23, 1), 2, 2,
+    dimnames = list(c("x", "y"), c("x", "y")))
+  labs <- text_labels(ggcorrplot(m, lab = TRUE, nsmall = 2, leading.zero = FALSE))
+  expect_true("1.00" %in% labs)          # the 0 in 1.00 is not a leading zero
+  expect_true("-.67" %in% labs)
+  expect_true(".23" %in% labs)
+  expect_false(any(labs == "1.0.0"))     # sanity: no double substitution
+})
+
+test_that("leading.zero = FALSE composes with sig.stars", {
+  corr <- round(cor(mtcars), 2)
+  p <- cor_pmat(mtcars)
+  labs <- text_labels(
+    ggcorrplot(corr, p.mat = p, lab = TRUE, sig.stars = TRUE, leading.zero = FALSE)
+  )
+  # a starred, zero-stripped label such as -.85*** exists, and none keep 0.
+  expect_true(any(grepl("^-?\\.[0-9]+\\*", labs)))
+  expect_false(any(grepl("^-?0\\.", labs)))
+})


### PR DESCRIPTION
Fixes #15 — with this, both of #15's requests are implemented: bold labels (`lab_fontface`, shipped earlier) and dropping the leading zero (this PR).

Addresses the second half of #15 (the first half — bold labels — shipped as `lab_fontface`). Adds a `leading.zero` argument so coefficient labels can be shown without the leading zero, e.g. `.23`/`-.67` instead of `0.23`/`-0.67`, a common convention for correlation tables.

``` r
library(ggcorrplot)
corr <- round(cor(mtcars), 2)
ggcorrplot(corr, type = "lower", lab = TRUE, leading.zero = FALSE)
```

- Default is `TRUE` (leading zero kept) — existing output is byte-identical.
- `FALSE` strips the leading zero of values in (-1, 1), including negatives; `1.00` and integers are left untouched (the `\b0(\.\d+)` idiom from @PawelKulawiak's comment on #15).
- Only used when `lab = TRUE`; composes with `nsmall`, `sig.stars`, and `insig = "blank"`.

New regression tests cover the byte-identical default, the strip (incl. negatives and stars), and that `1.00`/integers are preserved.
