### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@ tests\^spelling
 ^CLAUDE\.md$
 ^TODO\.md$
 ^Rplots\.pdf$
+^CRAN-SUBMISSION$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@ tests\^spelling
 ^\.github$
 ^\.claude$
 ^CLAUDE\.md$
+^TODO\.md$
+^Rplots\.pdf$

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .Ruserdata
 .DS_Store
 docs/.DS_Store
-.claude/skills/
+.claude/
 CLAUDE.md
 TODO.md
 Rplots.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 docs/.DS_Store
 .claude/skills/
 CLAUDE.md
+TODO.md
+Rplots.pdf

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.2.0
+Date: 2026-07-08 15:18:10 UTC
+SHA: 1adeeff15f50b10e0c6e828c6e26a791ec572db4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: ggcorrplot
 Title: Visualization of a Correlation Matrix using 'ggplot2'
-Version: 0.1.4.999
-Date: 2026-07-07
+Version: 0.2.0
+Date: 2026-07-08
 Authors@R: 
     c(person(given = "Alboukadel",
              family = "Kassambara",
@@ -19,7 +19,7 @@ Description: The 'ggcorrplot' package can be used to visualize easily a
     on the plot. It also includes a function for computing a matrix of
     correlation p-values.
 License: GPL-2
-URL: http://www.sthda.com/english/wiki/ggcorrplot-visualization-of-a-correlation-matrix-using-ggplot2
+URL: https://www.sthda.com/english/wiki/ggcorrplot-visualization-of-a-correlation-matrix-using-ggplot2
 BugReports: https://github.com/kassambara/ggcorrplot/issues
 Depends:
     R (>= 3.3),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ggcorrplot 0.1.4
+# ggcorrplot 0.2.0
 
 ## New features
 
@@ -51,16 +51,6 @@
   line up (@elizabethwe, #51).
 
 ## Minor changes
-  
-- New argument `as.is` added. A logical passed to melt.array. If TRUE, dimnames
-  will be left as strings instead of being converted using type.convert
-  (@fdetsch, [#24](https://github.com/kassambara/ggcorrplot/pull/24)).
-
-- Gets rid of `NOTE` in CRAN daily checks about lazy data.
-
-- Adds visual regression testing infrastructure using `vdiffr`.
-
-- Removes warnings stemming from the latest version of `ggplot2`.
 
 - Replaced the deprecated `ggplot2::aes_string()` with tidy-evaluation `aes()`
   internally, silencing the ggplot2 deprecation warnings on recent `ggplot2`
@@ -69,6 +59,11 @@
 
 - Added a `CITATION` file so `citation("ggcorrplot")` returns a proper
   reference (#42, #47).
+
+- Added an internal structural regression test suite that asserts on the built
+  plot (layer composition, built data, fill-scale semantics, coordinate system,
+  ordering and significance handling), so the plot's structure is checked on CI
+  and CRAN and not only by the local visual snapshots (#81).
 
 ## Bug fixes
 
@@ -106,6 +101,22 @@
   numeric-looking names. The p-value matrix is now reshaped with the same
   `as.is` setting as the correlation matrix, so `as.is = TRUE` no longer places
   the markers off-plot (@cabaez, #37).
+
+# ggcorrplot 0.1.4
+
+## Minor changes
+
+- New argument `as.is` added. A logical passed to melt.array. If TRUE, dimnames
+  will be left as strings instead of being converted using type.convert
+  (@fdetsch, [#24](https://github.com/kassambara/ggcorrplot/pull/24)).
+
+- Gets rid of `NOTE` in CRAN daily checks about lazy data.
+
+- Adds visual regression testing infrastructure using `vdiffr`.
+
+- Removes warnings stemming from the latest version of `ggplot2`.
+
+## Bug fixes
 
 - The option `hc.method` is now taken into account (#mitchelfruin, #29)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,7 +29,7 @@ knitr::opts_chunk$set(
 The **ggcorrplot** package can be used to **visualize easily** a **correlation matrix** using **ggplot2**. It provides a solution for **reordering** the correlation matrix and displays the **significance level** on the correlogram. It includes also a function for computing a matrix of **correlation p-values**. 
    
    
-Find out more at http://www.sthda.com/english/wiki/ggcorrplot-visualization-of-a-correlation-matrix-using-ggplot2.
+Find out more at https://www.sthda.com/english/wiki/ggcorrplot-visualization-of-a-correlation-matrix-using-ggplot2.
     
    
   

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ level** on the correlogram. It includes also a function for computing a
 matrix of **correlation p-values**.
 
 Find out more at
-<http://www.sthda.com/english/wiki/ggcorrplot-visualization-of-a-correlation-matrix-using-ggplot2>.
+<https://www.sthda.com/english/wiki/ggcorrplot-visualization-of-a-correlation-matrix-using-ggplot2>.
 
 ## Installation and loading
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,16 +1,25 @@
+## Submission
+
+This is a feature and bug-fix update (0.2.0), following the current CRAN version
+0.1.4.1. It adds several new, backward-compatible arguments to `ggcorrplot()`
+(`sig.stars`, `circle.scale`, `nsmall`, `legend.limit`, `coord.fixed`,
+`lab_fontface`, `leading.zero`, `tl.vjust`/`tl.hjust`), lets `colors` accept a
+palette of any length, adds a `use` argument to `cor_pmat()`, and fixes a number
+of defects (see NEWS.md). Default output for existing inputs is unchanged.
+
 ## Test environments
-* local OS X install, R 3.2.3
-* win-builder 
-* Travis
+* local macOS, R 4.5.x
+* GitHub Actions: macOS-release, Windows-release, Ubuntu-{devel, release, oldrel-1}
+* win-builder (devel and release) — to run before submission
 
 ## R CMD check results
-There were no ERRORs, WARNINGs or NOTEs. 
+Local `R CMD check --as-cran`: 0 errors | 0 warnings | 0 notes.
 
-I have also run R CMD check on downstream dependencies of ggcorrplot. 
-All packages that I could install passed.
+The only local note is "unable to verify current time" (the check host cannot
+reach a time server); it is environmental and does not appear on CI.
 
-## Update
-
-This is an update version 0.1.4 (see NEWS.md)
-
-
+## Reverse dependencies
+This release is additive: all new behavior is behind new arguments that default
+to the current behavior, and default output for existing inputs is byte-identical
+(covered by the test suite). A scoped reverse-dependency check is to be run before
+submission and its result recorded here.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -10,7 +10,8 @@ of defects (see NEWS.md). Default output for existing inputs is unchanged.
 ## Test environments
 * local macOS, R 4.5.x
 * GitHub Actions: macOS-release, Windows-release, Ubuntu-{devel, release, oldrel-1}
-* win-builder (devel and release) — to run before submission
+* win-builder release (R 4.x): OK
+* win-builder devel: submitted
 
 ## R CMD check results
 Local `R CMD check --as-cran`: 0 errors | 0 warnings | 0 notes.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -11,7 +11,7 @@ of defects (see NEWS.md). Default output for existing inputs is unchanged.
 * local macOS, R 4.5.x
 * GitHub Actions: macOS-release, Windows-release, Ubuntu-{devel, release, oldrel-1}
 * win-builder release (R 4.x): OK
-* win-builder devel: submitted
+* win-builder devel (R-devel): OK
 
 ## R CMD check results
 Local `R CMD check --as-cran`: 0 errors | 0 warnings | 0 notes.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -19,7 +19,12 @@ The only local note is "unable to verify current time" (the check host cannot
 reach a time server); it is environmental and does not appear on CI.
 
 ## Reverse dependencies
-This release is additive: all new behavior is behind new arguments that default
-to the current behavior, and default output for existing inputs is byte-identical
-(covered by the test suite). A scoped reverse-dependency check is to be run before
-submission and its result recorded here.
+Checked all 22 reverse dependencies with a source-level scan scoped to the
+behavior-changing surface of this release (the `hc.order` clustering/significance
+fixes, `tl.col` now being applied, and `cor_pmat()` returning `NA` instead of
+erroring for uncomputable pairs). No reverse dependency pins `ggcorrplot()` or
+`cor_pmat()` output in a test, snapshot, or `expect_error()`, and every caller
+supplies a square correlation matrix and default-compatible arguments, so no new
+problems are introduced. All other changes are additive: new behavior is behind
+new arguments whose defaults reproduce the current behavior, and default output
+for existing inputs is unchanged.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -2,6 +2,7 @@ bw
 cex
 correlogram
 english
+erroring
 ggplot
 ggtheme
 glyphs
@@ -9,6 +10,7 @@ hc
 hclust
 http
 insig
+misalign
 mitchelfruin
 mtcars
 pch
@@ -16,4 +18,5 @@ pmat
 rstatix
 sig
 sthda
+unrounded
 www

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-circle.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-circle.svg
@@ -25,6 +25,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw)'>
+<rect x='50.82' y='0.00' width='618.36' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -201,23 +202,23 @@
 <text transform='translate(489.62,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
 <text transform='translate(535.80,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
 <text transform='translate(581.99,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
 <image width='17.28' height='86.40' x='620.30' y='245.89' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAsUlEQVQ4jbWPwQ7DIAxDH2aTpv3/t05aW2CngWChTSvtYjmxYwMFingK8YiIewMhYkTchIgGyGLhOzaI/S60cTAHRNCvOlwE68Jix5b5bZ8Srlm8ve2DB+O0cn/se91tjo4zz/ifxfs+AioFVHKFMmEcW/ZTcBZ58y6e5WtRjrN8Ws3GS62ivBtlqr0wDciDz2nJRtEgmKOxS3WXhl1lFmypY2tlywZaEui9gV4rAKV8ANuwLHQSilYnAAAAAElFTkSuQmCC'/>
+<polyline points='634.12,332.14 637.58,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,310.61 637.58,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,289.09 637.58,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,267.56 637.58,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,246.03 637.58,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,332.14 620.30,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,310.61 620.30,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,289.09 620.30,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,267.56 620.30,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,246.03 620.30,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
 <text x='643.06' y='335.17' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
 <text x='643.06' y='313.64' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
 <text x='643.06' y='292.11' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='643.06' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='643.06' y='249.06' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
-<line x1='620.30' y1='332.14' x2='623.76' y2='332.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='310.61' x2='623.76' y2='310.61' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='289.09' x2='623.76' y2='289.09' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='267.56' x2='623.76' y2='267.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='246.03' x2='623.76' y2='246.03' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='332.14' x2='637.58' y2='332.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='310.61' x2='637.58' y2='310.61' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='289.09' x2='637.58' y2='289.09' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='267.56' x2='637.58' y2='267.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='246.03' x2='637.58' y2='246.03' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
 <text x='86.59' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='139.39px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - circle</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-default.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-default.svg
@@ -25,6 +25,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw)'>
+<rect x='50.82' y='0.00' width='618.36' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -56,127 +57,127 @@
 <polyline points='483.78,540.06 483.78,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='529.96,540.06 529.96,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='576.15,540.06 576.15,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<rect x='91.21' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='137.39' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #502BFF;' />
-<rect x='183.58' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='229.76' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='275.95' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='322.13' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #502BFF;' />
-<rect x='368.32' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='414.50' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='460.69' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF8969;' />
-<rect x='506.87' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF9E81;' />
-<rect x='553.06' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='91.21' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #502BFF;' />
-<rect x='137.39' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='183.58' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF3E22;' />
-<rect x='229.76' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='275.95' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='322.13' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='368.32' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='414.50' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='460.69' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #B38BFF;' />
-<rect x='506.87' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #B38BFF;' />
-<rect x='553.06' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF9E81;' />
-<rect x='91.21' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='137.39' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF3E22;' />
-<rect x='183.58' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='229.76' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='275.95' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='322.13' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF3E22;' />
-<rect x='368.32' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #C4A2FF;' />
-<rect x='414.50' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='460.69' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='506.87' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='553.06' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='91.21' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='137.39' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='183.58' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='229.76' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='275.95' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #C4A2FF;' />
-<rect x='322.13' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='368.32' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='414.50' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='460.69' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='506.87' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #F2E7FF;' />
-<rect x='553.06' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='91.21' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='137.39' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='183.58' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='229.76' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #C4A2FF;' />
-<rect x='275.95' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='322.13' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='368.32' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFECE5;' />
-<rect x='414.50' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='460.69' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='506.87' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='553.06' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #F2E7FF;' />
-<rect x='91.21' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #502BFF;' />
-<rect x='137.39' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='183.58' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF3E22;' />
-<rect x='229.76' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='275.95' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='322.13' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='368.32' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='414.50' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='460.69' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='506.87' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='553.06' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='91.21' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='137.39' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='183.58' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #C4A2FF;' />
-<rect x='229.76' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='275.95' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFECE5;' />
-<rect x='322.13' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='368.32' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='414.50' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='460.69' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='506.87' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='553.06' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='91.21' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='137.39' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='183.58' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='229.76' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='275.95' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='322.13' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='368.32' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='414.50' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='460.69' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFD9CB;' />
-<rect x='506.87' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFD9CB;' />
-<rect x='553.06' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='91.21' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF8969;' />
-<rect x='137.39' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #B38BFF;' />
-<rect x='183.58' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='229.76' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='275.95' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='322.13' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='368.32' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='414.50' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFD9CB;' />
-<rect x='460.69' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='506.87' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='553.06' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFECE5;' />
-<rect x='91.21' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF9E81;' />
-<rect x='137.39' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #B38BFF;' />
-<rect x='183.58' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='229.76' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #F2E7FF;' />
-<rect x='275.95' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='322.13' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='368.32' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='414.50' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFD9CB;' />
-<rect x='460.69' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='506.87' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='553.06' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFC6B2;' />
-<rect x='91.21' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='137.39' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF9E81;' />
-<rect x='183.58' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='229.76' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='275.95' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #F2E7FF;' />
-<rect x='322.13' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='368.32' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='414.50' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='460.69' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFECE5;' />
-<rect x='506.87' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FFC6B2;' />
-<rect x='553.06' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #BEBEBE; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='91.21' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='137.39' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='183.58' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='229.76' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='275.95' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='322.13' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='368.32' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='414.50' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='460.69' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF8969;' />
+<rect x='506.87' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='553.06' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='91.21' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='137.39' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='183.58' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='229.76' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='275.95' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='368.32' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='414.50' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='460.69' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='506.87' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='553.06' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='91.21' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='137.39' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='183.58' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='229.76' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='275.95' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='368.32' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='414.50' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='460.69' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='506.87' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='553.06' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='91.21' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='137.39' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='183.58' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='229.76' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='275.95' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='322.13' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='368.32' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='414.50' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='460.69' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='506.87' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='553.06' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='91.21' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='137.39' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='183.58' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='229.76' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='275.95' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='322.13' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='368.32' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='414.50' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='460.69' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='506.87' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='553.06' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='91.21' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='137.39' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='183.58' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='229.76' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='275.95' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='368.32' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='414.50' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='460.69' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='506.87' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='553.06' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='91.21' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='137.39' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='183.58' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='229.76' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='275.95' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='322.13' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='368.32' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='414.50' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='460.69' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='506.87' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='553.06' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='91.21' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='137.39' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='183.58' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='229.76' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='275.95' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='322.13' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='368.32' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='414.50' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='460.69' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='506.87' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='553.06' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='91.21' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF8969;' />
+<rect x='137.39' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='183.58' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='229.76' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='275.95' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='322.13' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='368.32' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='414.50' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='460.69' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='506.87' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='553.06' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='91.21' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='137.39' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='183.58' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='229.76' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='275.95' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='322.13' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='368.32' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='414.50' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='460.69' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='506.87' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='553.06' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC6B2;' />
+<rect x='91.21' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='137.39' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='183.58' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='229.76' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='275.95' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='322.13' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='368.32' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='414.50' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='460.69' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='506.87' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC6B2;' />
+<rect x='553.06' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='81.66' y='516.47' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
@@ -201,23 +202,23 @@
 <text transform='translate(489.62,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
 <text transform='translate(535.80,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
 <text transform='translate(581.99,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
 <image width='17.28' height='86.40' x='620.30' y='245.89' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAsUlEQVQ4jbWPwQ7DIAxDH2aTpv3/t05aW2CngWChTSvtYjmxYwMFingK8YiIewMhYkTchIgGyGLhOzaI/S60cTAHRNCvOlwE68Jix5b5bZ8Srlm8ve2DB+O0cn/se91tjo4zz/ifxfs+AioFVHKFMmEcW/ZTcBZ58y6e5WtRjrN8Ws3GS62ivBtlqr0wDciDz2nJRtEgmKOxS3WXhl1lFmypY2tlywZaEui9gV4rAKV8ANuwLHQSilYnAAAAAElFTkSuQmCC'/>
+<polyline points='634.12,332.14 637.58,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,310.61 637.58,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,289.09 637.58,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,267.56 637.58,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,246.03 637.58,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,332.14 620.30,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,310.61 620.30,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,289.09 620.30,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,267.56 620.30,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,246.03 620.30,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
 <text x='643.06' y='335.17' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
 <text x='643.06' y='313.64' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
 <text x='643.06' y='292.11' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='643.06' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='643.06' y='249.06' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
-<line x1='620.30' y1='332.14' x2='623.76' y2='332.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='310.61' x2='623.76' y2='310.61' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='289.09' x2='623.76' y2='289.09' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='267.56' x2='623.76' y2='267.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='246.03' x2='623.76' y2='246.03' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='332.14' x2='637.58' y2='332.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='310.61' x2='637.58' y2='310.61' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='289.09' x2='637.58' y2='289.09' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='267.56' x2='637.58' y2='267.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='246.03' x2='637.58' y2='246.03' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
 <text x='86.59' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='148.21px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - default</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-hc.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-hc.svg
@@ -25,6 +25,7 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw)'>
+<rect x='50.82' y='0.00' width='618.36' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
@@ -56,127 +57,127 @@
 <polyline points='483.78,540.06 483.78,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='529.96,540.06 529.96,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
 <polyline points='576.15,540.06 576.15,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
-<rect x='91.21' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='137.39' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='183.58' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='229.76' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF9E81;' />
-<rect x='275.95' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='322.13' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='368.32' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='414.50' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFECE5;' />
-<rect x='460.69' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFC6B2;' />
-<rect x='506.87' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='553.06' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #F2E7FF;' />
-<rect x='91.21' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='137.39' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='183.58' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='229.76' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='275.95' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF3E22;' />
-<rect x='322.13' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='368.32' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='414.50' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='460.69' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='506.87' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #502BFF;' />
-<rect x='553.06' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='91.21' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='137.39' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='183.58' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='229.76' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='275.95' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='322.13' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='368.32' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='414.50' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='460.69' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #F2E7FF;' />
-<rect x='506.87' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='553.06' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #C4A2FF;' />
-<rect x='91.21' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF9E81;' />
-<rect x='137.39' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='183.58' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='229.76' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='275.95' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF3E22;' />
-<rect x='322.13' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='368.32' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='414.50' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #B38BFF;' />
-<rect x='460.69' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #B38BFF;' />
-<rect x='506.87' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #502BFF;' />
-<rect x='553.06' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='91.21' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='137.39' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF3E22;' />
-<rect x='183.58' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='229.76' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF3E22;' />
-<rect x='275.95' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='322.13' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #C4A2FF;' />
-<rect x='368.32' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='414.50' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='460.69' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='506.87' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='553.06' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='91.21' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='137.39' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='183.58' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='229.76' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='275.95' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #C4A2FF;' />
-<rect x='322.13' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='368.32' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='414.50' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='460.69' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='506.87' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='553.06' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFECE5;' />
-<rect x='91.21' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='137.39' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='183.58' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='229.76' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='275.95' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='322.13' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='368.32' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='414.50' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFD9CB;' />
-<rect x='460.69' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFD9CB;' />
-<rect x='506.87' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='553.06' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='91.21' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFECE5;' />
-<rect x='137.39' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='183.58' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='229.76' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #B38BFF;' />
-<rect x='275.95' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='322.13' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='368.32' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFD9CB;' />
-<rect x='414.50' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='460.69' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='506.87' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF8969;' />
-<rect x='553.06' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='91.21' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFC6B2;' />
-<rect x='137.39' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='183.58' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #F2E7FF;' />
-<rect x='229.76' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #B38BFF;' />
-<rect x='275.95' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='322.13' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #E3D0FF;' />
-<rect x='368.32' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFD9CB;' />
-<rect x='414.50' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF5B3A;' />
-<rect x='460.69' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='506.87' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF9E81;' />
-<rect x='553.06' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='91.21' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A074FF;' />
-<rect x='137.39' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #502BFF;' />
-<rect x='183.58' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='229.76' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #502BFF;' />
-<rect x='275.95' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #7145FF;' />
-<rect x='322.13' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='368.32' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='414.50' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF8969;' />
-<rect x='460.69' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF9E81;' />
-<rect x='506.87' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
-<rect x='553.06' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='91.21' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #F2E7FF;' />
-<rect x='137.39' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='183.58' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #C4A2FF;' />
-<rect x='229.76' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='275.95' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8A5DFF;' />
-<rect x='322.13' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFECE5;' />
-<rect x='368.32' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FFB299;' />
-<rect x='414.50' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='460.69' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='506.87' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF7352;' />
-<rect x='553.06' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='91.21' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='137.39' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='183.58' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='229.76' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='275.95' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='322.13' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='368.32' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='414.50' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='460.69' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC6B2;' />
+<rect x='506.87' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='553.06' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='91.21' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='137.39' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='183.58' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='229.76' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='275.95' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='322.13' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='368.32' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='414.50' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='460.69' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='506.87' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='553.06' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='91.21' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='137.39' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='183.58' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='229.76' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='275.95' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='322.13' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='368.32' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='414.50' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='460.69' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='506.87' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='553.06' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='91.21' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='137.39' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='183.58' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='229.76' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='275.95' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='322.13' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='368.32' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='414.50' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='460.69' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='506.87' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='553.06' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='91.21' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='137.39' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='183.58' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='229.76' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='275.95' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='322.13' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='368.32' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='414.50' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='460.69' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='506.87' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='553.06' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='91.21' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='137.39' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='183.58' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='229.76' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='275.95' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='322.13' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='368.32' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='414.50' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='460.69' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='506.87' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='553.06' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='91.21' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='137.39' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='183.58' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='229.76' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='275.95' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='368.32' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='414.50' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='460.69' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='506.87' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='553.06' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='91.21' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='137.39' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='183.58' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='229.76' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='275.95' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='322.13' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='368.32' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='414.50' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='460.69' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='506.87' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF8969;' />
+<rect x='553.06' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='91.21' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC6B2;' />
+<rect x='137.39' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='183.58' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='229.76' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='275.95' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='322.13' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='368.32' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='414.50' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='460.69' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='506.87' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='553.06' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='91.21' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='137.39' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='183.58' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='229.76' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='275.95' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='322.13' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='368.32' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='414.50' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF8969;' />
+<rect x='460.69' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='506.87' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='553.06' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='91.21' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='137.39' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='183.58' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='229.76' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='275.95' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='368.32' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='414.50' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='460.69' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='506.87' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='553.06' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <text x='81.66' y='516.47' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
@@ -201,23 +202,23 @@
 <text transform='translate(489.62,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
 <text transform='translate(535.80,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
 <text transform='translate(581.99,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
 <image width='17.28' height='86.40' x='620.30' y='245.89' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAsUlEQVQ4jbWPwQ7DIAxDH2aTpv3/t05aW2CngWChTSvtYjmxYwMFingK8YiIewMhYkTchIgGyGLhOzaI/S60cTAHRNCvOlwE68Jix5b5bZ8Srlm8ve2DB+O0cn/se91tjo4zz/ifxfs+AioFVHKFMmEcW/ZTcBZ58y6e5WtRjrN8Ws3GS62ivBtlqr0wDciDz2nJRtEgmKOxS3WXhl1lFmypY2tlywZaEui9gV4rAKV8ANuwLHQSilYnAAAAAElFTkSuQmCC'/>
+<polyline points='634.12,332.14 637.58,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,310.61 637.58,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,289.09 637.58,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,267.56 637.58,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,246.03 637.58,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,332.14 620.30,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,310.61 620.30,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,289.09 620.30,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,267.56 620.30,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,246.03 620.30,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
 <text x='643.06' y='335.17' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
 <text x='643.06' y='313.64' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
 <text x='643.06' y='292.11' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
 <text x='643.06' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
 <text x='643.06' y='249.06' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
-<line x1='620.30' y1='332.14' x2='623.76' y2='332.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='310.61' x2='623.76' y2='310.61' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='289.09' x2='623.76' y2='289.09' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='267.56' x2='623.76' y2='267.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='620.30' y1='246.03' x2='623.76' y2='246.03' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='332.14' x2='637.58' y2='332.14' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='310.61' x2='637.58' y2='310.61' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='289.09' x2='637.58' y2='289.09' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='267.56' x2='637.58' y2='267.56' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
-<line x1='634.12' y1='246.03' x2='637.58' y2='246.03' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
 <text x='86.59' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='122.53px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - hc</text>
 </g>
 </svg>


### PR DESCRIPTION
Prepares the 0.2.0 release. This is a feature and bug-fix update over the current CRAN version (0.1.4.1); default output for existing inputs is unchanged.

The branch is bookkeeping only — no `R/` or `man/` changes. It bumps the version and date, reorganizes NEWS into a 0.2.0 section (accrued features and fixes, four-section convention, contributor credits kept) split from the released 0.1.4 section, fixes the STHDA URL at source, refreshes the WORDLIST and cran-comments, and regenerates the vdiffr snapshots for the current ggplot2/svglite (visually verified as unchanged in content).

`R CMD check --as-cran` is 0/0/0 locally (only the environmental "unable to verify current time" note). urlchecker and spelling are clean; the full test suite passes.

Not for merge yet: per the release process the branch is held until CRAN accepts, so master stays on the dev version and the tarball is built from this branch. win-builder, the scoped revdep check, and the CRAN submission remain to be done.

Refs #82
