### PR TITLE
Start next development cycle (0.2.0.9000)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: ggcorrplot
 Title: Visualization of a Correlation Matrix using 'ggplot2'
-Version: 0.2.0
+Version: 0.2.0.9000
 Date: 2026-07-08
 Authors@R: 
     c(person(given = "Alboukadel",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ggcorrplot 0.2.0.9000
+
 # ggcorrplot 0.2.0
 
 ## New features


### PR DESCRIPTION
Opens the post-0.2.0 development cycle: bumps the version to 0.2.0.9000 and adds the dev heading to NEWS. No code change.

Refs #82
