### PR TITLE
Factor the plot pipeline into internal builders

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # ggcorrplot 0.2.0.9000
 
+## Minor changes
+
+- Internal refactor: the data-preparation pipeline and the glyph-layer
+  construction are now factored into internal helpers, with no change to the
+  output of any existing call. This is groundwork for forthcoming per-triangle
+  layout options.
+
 # ggcorrplot 0.2.0
 
 ## New features

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -225,77 +225,18 @@ ggcorrplot <- function(corr,
   }
   corr <- as.matrix(corr)
 
-  # Reordering and the triangular layouts require a square matrix; a non-square
-  # (m x n) correlation matrix can only be shown in full (#5, #10).
-  if (nrow(corr) != ncol(corr)) {
-    if (hc.order) {
-      stop("hc.order = TRUE requires a square correlation matrix.")
-    }
-    if (type != "full") {
-      stop("type = '", type, "' requires a square correlation matrix; ",
-           "use type = 'full' for a non-square matrix.")
-    }
-  }
-
-  # Order on the unrounded matrix so the internal rounding below does not
-  # introduce ties that perturb the hierarchical clustering (#14).
-  if (hc.order) {
-    ord <- .hc_cormat_order(corr, hc.method = hc.method)
-    corr <- corr[ord, ord]
-    if (!is.null(p.mat)) {
-      p.mat <- p.mat[ord, ord]
-    }
-  }
-
-  corr <- base::round(x = corr, digits = digits)
-
-  if (!show.diag) {
-    corr <- .remove_diag(corr)
-    p.mat <- .remove_diag(p.mat)
-  }
-
-  # Get lower or upper triangle
-  if (type == "lower") {
-    corr <- .get_lower_tri(corr, show.diag)
-    p.mat <- .get_lower_tri(p.mat, show.diag)
-  } else if (type == "upper") {
-    corr <- .get_upper_tri(corr, show.diag)
-    p.mat <- .get_upper_tri(p.mat, show.diag)
-  }
-
-  # Melt corr and pmat
-  corr <- reshape2::melt(corr, na.rm = TRUE, as.is = as.is)
-  colnames(corr) <- c("Var1", "Var2", "value")
-  corr$pvalue <- rep(NA, nrow(corr))
-  corr$signif <- rep(NA, nrow(corr))
-
-  if (!is.null(p.mat)) {
-    p.mat <- reshape2::melt(p.mat, na.rm = TRUE, as.is = as.is)
-    colnames(p.mat) <- c("Var1", "Var2", "value")
-    # Match each p-value to its correlation cell by (Var1, Var2) rather than by
-    # row position, so a differing NA pattern between corr and p.mat cannot
-    # misalign them (or raise a length error). When the patterns match, the
-    # match is the identity and the result is byte-identical.
-    idx <- match(
-      paste(corr$Var1, corr$Var2, sep = "\r"),
-      paste(p.mat$Var1, p.mat$Var2, sep = "\r")
-    )
-    corr$coef <- corr$value
-    corr$pvalue <- p.mat$value[idx]
-    corr$signif <- as.numeric(corr$pvalue <= sig.level)
-    p.mat <- subset(p.mat, p.mat$value > sig.level)
-    # keep significance markers only for cells present in the correlation plot
-    p.mat <- p.mat[paste(p.mat$Var1, p.mat$Var2, sep = "\r") %in%
-      paste(corr$Var1, corr$Var2, sep = "\r"), ]
-    if (insig == "blank") {
-      # a cell with no matching p-value (unknown significance) is kept as-is
-      keep <- ifelse(is.na(corr$signif), 1, corr$signif)
-      corr$value <- corr$value * keep
-    }
-  }
-
-
-  corr$abs_corr <- abs(corr$value) * 10
+  # Transform the correlation (and matching p-value) matrix into the long
+  # data frames the plot is built from: reorder, round, mask a triangle, melt,
+  # and join per-cell significance. Extracted so the mixed-method path can reuse
+  # exactly the same pipeline (P0.0). Returns the melted `corr` data frame and
+  # the insignificant-cells `p.mat` data frame (or NULL).
+  built <- .build_corr_df(
+    corr = corr, p.mat = p.mat, type = type, show.diag = show.diag,
+    hc.order = hc.order, hc.method = hc.method, digits = digits,
+    sig.level = sig.level, insig = insig, as.is = as.is
+  )
+  corr <- built$corr
+  p.mat <- built$p.mat
 
   # heatmap
   p <-
@@ -304,20 +245,9 @@ ggcorrplot <- function(corr,
       mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]], fill = .data[["value"]])
     )
 
-  # modification based on method
-  if (method == "square") {
-    p <- p +
-      ggplot2::geom_tile(color = outline.color)
-  } else if (method == "circle") {
-    p <- p +
-      ggplot2::geom_point(
-        color = outline.color,
-        shape = 21,
-        ggplot2::aes(size = .data[["abs_corr"]])
-      ) +
-      ggplot2::scale_size(range = c(4, 10) * circle.scale) +
-      ggplot2::guides(size = "none")
-  }
+  # modification based on method (extracted so the mixed-method path can request
+  # a different glyph per triangle from the same builder, P0.0)
+  p <- p + .method_layer(method, outline.color = outline.color, circle.scale = circle.scale)
 
   # adding colors
   if (length(colors) < 2) {
@@ -516,6 +446,114 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
 #+++++++++++++++++++++++
 # Helper Functions
 #+++++++++++++++++++++++
+
+# Reorder -> round -> mask a triangle -> melt -> join per-cell significance.
+# Takes the already-coerced correlation matrix and (optional) p-value matrix and
+# the resolved show.diag, and returns the two long data frames the plot layers
+# are built from:
+#   $corr  : melted correlation data frame (Var1, Var2, value, pvalue, signif,
+#            [coef], abs_corr)
+#   $p.mat : the insignificant-cells data frame used by the insig = "pch" layer,
+#            or NULL when no p.mat was supplied.
+# Behaviour is identical to the inline pipeline it was extracted from (P0.0); the
+# order of operations matters (round happens AFTER clustering and the
+# significance test, #14/#25) and is preserved exactly.
+.build_corr_df <- function(corr, p.mat, type, show.diag, hc.order, hc.method,
+                           digits, sig.level, insig, as.is) {
+  # Reordering and the triangular layouts require a square matrix; a non-square
+  # (m x n) correlation matrix can only be shown in full (#5, #10).
+  if (nrow(corr) != ncol(corr)) {
+    if (hc.order) {
+      stop("hc.order = TRUE requires a square correlation matrix.")
+    }
+    if (type != "full") {
+      stop("type = '", type, "' requires a square correlation matrix; ",
+           "use type = 'full' for a non-square matrix.")
+    }
+  }
+
+  # Order on the unrounded matrix so the internal rounding below does not
+  # introduce ties that perturb the hierarchical clustering (#14).
+  if (hc.order) {
+    ord <- .hc_cormat_order(corr, hc.method = hc.method)
+    corr <- corr[ord, ord]
+    if (!is.null(p.mat)) {
+      p.mat <- p.mat[ord, ord]
+    }
+  }
+
+  corr <- base::round(x = corr, digits = digits)
+
+  if (!show.diag) {
+    corr <- .remove_diag(corr)
+    p.mat <- .remove_diag(p.mat)
+  }
+
+  # Get lower or upper triangle
+  if (type == "lower") {
+    corr <- .get_lower_tri(corr, show.diag)
+    p.mat <- .get_lower_tri(p.mat, show.diag)
+  } else if (type == "upper") {
+    corr <- .get_upper_tri(corr, show.diag)
+    p.mat <- .get_upper_tri(p.mat, show.diag)
+  }
+
+  # Melt corr and pmat
+  corr <- reshape2::melt(corr, na.rm = TRUE, as.is = as.is)
+  colnames(corr) <- c("Var1", "Var2", "value")
+  corr$pvalue <- rep(NA, nrow(corr))
+  corr$signif <- rep(NA, nrow(corr))
+
+  if (!is.null(p.mat)) {
+    p.mat <- reshape2::melt(p.mat, na.rm = TRUE, as.is = as.is)
+    colnames(p.mat) <- c("Var1", "Var2", "value")
+    # Match each p-value to its correlation cell by (Var1, Var2) rather than by
+    # row position, so a differing NA pattern between corr and p.mat cannot
+    # misalign them (or raise a length error). When the patterns match, the
+    # match is the identity and the result is byte-identical.
+    idx <- match(
+      paste(corr$Var1, corr$Var2, sep = "\r"),
+      paste(p.mat$Var1, p.mat$Var2, sep = "\r")
+    )
+    corr$coef <- corr$value
+    corr$pvalue <- p.mat$value[idx]
+    corr$signif <- as.numeric(corr$pvalue <= sig.level)
+    p.mat <- subset(p.mat, p.mat$value > sig.level)
+    # keep significance markers only for cells present in the correlation plot
+    p.mat <- p.mat[paste(p.mat$Var1, p.mat$Var2, sep = "\r") %in%
+      paste(corr$Var1, corr$Var2, sep = "\r"), ]
+    if (insig == "blank") {
+      # a cell with no matching p-value (unknown significance) is kept as-is
+      keep <- ifelse(is.na(corr$signif), 1, corr$signif)
+      corr$value <- corr$value * keep
+    }
+  } else {
+    p.mat <- NULL
+  }
+
+  corr$abs_corr <- abs(corr$value) * 10
+
+  list(corr = corr, p.mat = p.mat)
+}
+
+# Build the glyph layer(s) for a given method. Returns a list of ggplot
+# components so the caller can add them with a single `+` (and so the
+# mixed-method path can request a different glyph per triangle, P0.0).
+.method_layer <- function(method, outline.color, circle.scale) {
+  if (method == "square") {
+    list(ggplot2::geom_tile(color = outline.color))
+  } else if (method == "circle") {
+    list(
+      ggplot2::geom_point(
+        color = outline.color,
+        shape = 21,
+        ggplot2::aes(size = .data[["abs_corr"]])
+      ),
+      ggplot2::scale_size(range = c(4, 10) * circle.scale),
+      ggplot2::guides(size = "none")
+    )
+  }
+}
 
 # Get lower triangle of the correlation matrix
 .get_lower_tri <- function(cormat, show.diag = FALSE) {

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -1,0 +1,80 @@
+# Contract of the internal builders extracted from ggcorrplot() (P0.0).
+# These helpers are unexported, but the mixed-method and ellipse paths are built
+# on them, so their return shape is a real contract worth pinning. The behavior
+# they produce is covered byte-for-byte by test-structure.R (the plot is
+# unchanged by the extraction); here we lock the shape of what they return.
+
+corr <- round(cor(mtcars), 1)
+p.mat <- cor_pmat(mtcars)
+n <- ncol(mtcars)
+
+test_that(".build_corr_df returns the melted corr frame and a NULL p.mat when none is given", {
+  b <- .build_corr_df(
+    corr = corr, p.mat = NULL, type = "full", show.diag = TRUE,
+    hc.order = FALSE, hc.method = "complete", digits = 2,
+    sig.level = 0.05, insig = "pch", as.is = FALSE
+  )
+  expect_named(b, c("corr", "p.mat"))
+  expect_s3_class(b$corr, "data.frame")
+  expect_null(b$p.mat)
+  expect_true(all(c("Var1", "Var2", "value", "pvalue", "signif", "abs_corr") %in% names(b$corr)))
+  expect_equal(nrow(b$corr), n * n)
+  # with no p.mat, significance columns are all NA
+  expect_true(all(is.na(b$corr$pvalue)))
+})
+
+test_that(".build_corr_df joins p-values and returns the insignificant-cells frame", {
+  b <- .build_corr_df(
+    corr = corr, p.mat = p.mat, type = "full", show.diag = TRUE,
+    hc.order = FALSE, hc.method = "complete", digits = 2,
+    sig.level = 0.05, insig = "pch", as.is = FALSE
+  )
+  expect_s3_class(b$p.mat, "data.frame")
+  # the p.mat frame holds exactly the cells with p > sig.level
+  expect_equal(nrow(b$p.mat), sum(p.mat > 0.05))
+  # every corr cell's pvalue is its own (Var1, Var2) pair's p-value
+  expected <- p.mat[cbind(as.character(b$corr$Var1), as.character(b$corr$Var2))]
+  expect_equal(b$corr$pvalue, unname(expected))
+})
+
+test_that(".build_corr_df applies the triangle mask via row count", {
+  tri <- n * (n - 1) / 2
+  lower <- .build_corr_df(
+    corr = corr, p.mat = NULL, type = "lower", show.diag = FALSE,
+    hc.order = FALSE, hc.method = "complete", digits = 2,
+    sig.level = 0.05, insig = "pch", as.is = FALSE
+  )
+  expect_equal(nrow(lower$corr), tri)
+})
+
+test_that(".build_corr_df errors on a non-square matrix with hc.order or a triangle", {
+  ns <- cor(mtcars)[1:3, 1:5]
+  expect_error(
+    .build_corr_df(ns, NULL, "full", TRUE, TRUE, "complete", 2, 0.05, "pch", FALSE),
+    "square"
+  )
+  expect_error(
+    .build_corr_df(ns, NULL, "lower", FALSE, FALSE, "complete", 2, 0.05, "pch", FALSE),
+    "square"
+  )
+})
+
+test_that(".method_layer returns a single tile layer for square", {
+  layers <- .method_layer("square", outline.color = "gray", circle.scale = 1)
+  expect_type(layers, "list")
+  expect_length(layers, 1)
+  expect_s3_class(layers[[1]], "LayerInstance")
+  expect_s3_class(layers[[1]]$geom, "GeomTile")
+})
+
+test_that(".method_layer returns a point layer plus size scale and guide for circle", {
+  layers <- .method_layer("circle", outline.color = "gray", circle.scale = 1)
+  expect_length(layers, 3)
+  expect_s3_class(layers[[1]], "LayerInstance")
+  expect_s3_class(layers[[1]]$geom, "GeomPoint")
+  expect_s3_class(layers[[2]], "Scale")
+  # the layers add cleanly onto a ggplot (the caller does p + .method_layer(...))
+  d <- .build_corr_df(corr, NULL, "full", TRUE, FALSE, "complete", 2, 0.05, "pch", FALSE)$corr
+  p <- ggplot2::ggplot(d, ggplot2::aes(Var1, Var2, fill = value)) + layers
+  expect_s3_class(ggplot2::ggplotGrob(p), "gtable")
+})


### PR DESCRIPTION
Factors the transform-then-plot pipeline of `ggcorrplot()` into two internal helpers:

- `.build_corr_df()` — reorder, round, triangle mask, melt, and per-cell significance join; returns the long data frames the layers are built from.
- `.method_layer()` — builds the glyph layer(s) for a given method.

No user-facing change: output is identical for every existing call (verified across a 58-combination fingerprint of the built plot, and by the visual snapshots). This is groundwork for the per-triangle layout options.

Adds `tests/testthat/test-internals.R` pinning the helpers' return contract; the existing structural and visual tests continue to guard the output.
