### PR TITLE
Add a mixed layout: a different glyph per triangle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # ggcorrplot 0.2.0.9000
 
+## New features
+
+- New arguments `lower.method` and `upper.method` for a mixed layout: a different
+  glyph per triangle, e.g. the coefficients as numbers in the lower triangle,
+  circles in the upper, and the variable names on the diagonal
+  (`ggcorrplot(corr, lower.method = "number", upper.method = "circle")`). Each
+  accepts "square", "circle" or "number"; both default to `NULL`, leaving the
+  single-method output unchanged (#85). Requested by @Breeze-Hu.
+
 ## Minor changes
 
 - Internal refactor: the data-preparation pipeline and the glyph-layer

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -6,7 +6,19 @@
 #' @param corr the correlation matrix to visualize
 #' @param method character, the visualization method of correlation matrix to be
 #'   used. Allowed values are "square" (default), "circle".
-#' @param type character, "full" (default), "lower" or "upper" display.
+#' @param lower.method,upper.method character, an optional per-triangle glyph for
+#'   a mixed layout: one of "square", "circle" or "number" (the coefficient drawn
+#'   as text, colored by its value on the same scale as the fill, so coefficients
+#'   near zero are faint). When either is set, the plot switches to a mixed layout
+#'   where the lower and upper triangles are drawn separately and the variable
+#'   names are drawn on the diagonal; a triangle left \code{NULL} uses
+#'   \code{method}. Both default to \code{NULL} (single-method plot, unchanged).
+#'   In a mixed layout the single-method significance and label overlays
+#'   (\code{lab}, \code{sig.stars}, \code{p.mat}, \code{insig}, \code{pch*}) do
+#'   not apply; show coefficients with a "number" triangle instead.
+#' @param type character, "full" (default), "lower" or "upper" display. A mixed
+#'   layout (see \code{lower.method}/\code{upper.method}) always uses the full
+#'   matrix.
 #' @param ggtheme ggplot2 function or theme object. Default value is
 #'   `theme_minimal`. Allowed values are the official ggplot2 themes including
 #'   theme_gray, theme_bw, theme_minimal, theme_classic, theme_void, .... Theme
@@ -102,6 +114,14 @@
 #' # method = "square" or "circle"
 #' ggcorrplot(corr)
 #' ggcorrplot(corr, method = "circle")
+#'
+#' # Mixed layout: a different glyph per triangle
+#' # --------------------------------
+#' # numbers in the lower triangle, circles in the upper, names on the diagonal
+#' ggcorrplot(corr,
+#'   lower.method = "number", upper.method = "circle",
+#'   show.legend = FALSE
+#' )
 #'
 #' # Reordering the correlation matrix
 #' # --------------------------------
@@ -201,7 +221,9 @@ ggcorrplot <- function(corr,
                        leading.zero = TRUE,
                        legend.limit = c(-1, 1),
                        circle.scale = 1,
-                       coord.fixed = TRUE) {
+                       coord.fixed = TRUE,
+                       lower.method = NULL,
+                       upper.method = NULL) {
   type <- match.arg(type)
   method <- match.arg(method)
   insig <- match.arg(insig)
@@ -210,6 +232,36 @@ ggcorrplot <- function(corr,
       show.diag <- TRUE
     } else {
       show.diag <- FALSE
+    }
+  }
+
+  # Mixed layout: a different glyph per triangle (and the diagonal), requested via
+  # the per-triangle arguments. Mixed mode fires only when at least one of them is
+  # set, so every call that leaves them NULL (all existing calls) takes the
+  # unchanged single-method path below and is byte-identical. "number" (a text
+  # coefficient) is a value of these per-triangle arguments only; it is
+  # deliberately NOT added to the scalar `method` choice set, whose match.arg must
+  # keep resolving c("square","circle") to "square" (#85). The diagonal always
+  # shows the variable names in a mixed layout (there is intentionally no
+  # `diag.*` argument: any such name would start with "d" and make an abbreviated
+  # `digits` call, e.g. `ggcorrplot(x, d = 2)`, ambiguous -- a CRAN regression).
+  mixed <- !is.null(lower.method) || !is.null(upper.method)
+  if (mixed) {
+    glyphs <- c("square", "circle", "number")
+    lower.method <- if (is.null(lower.method)) method else match.arg(lower.method, glyphs)
+    upper.method <- if (is.null(upper.method)) method else match.arg(upper.method, glyphs)
+    # A mixed layout draws both triangles and the diagonal, i.e. the full matrix.
+    type <- "full"
+    show.diag <- TRUE
+    # The single-method coefficient/significance overlays do not apply to a mixed
+    # layout (the coefficients are a region glyph via lower/upper.method =
+    # "number"). Tell the user rather than dropping their arguments silently.
+    if (lab || sig.stars || !is.null(p.mat)) {
+      message(
+        "In a mixed layout, `lab`, `sig.stars`, `p.mat`, `insig` and `pch*` are ",
+        "not applied; use lower.method/upper.method = \"number\" to show the ",
+        "coefficients."
+      )
     }
   }
 
@@ -225,6 +277,21 @@ ggcorrplot <- function(corr,
   }
   corr <- as.matrix(corr)
 
+  if (mixed) {
+    if (nrow(corr) != ncol(corr)) {
+      stop("A mixed layout (lower.method/upper.method) requires a square ",
+           "correlation matrix.", call. = FALSE)
+    }
+    # The mixed layout splits cells by grid position and names the diagonal from
+    # the row variable, so the diagonal is only meaningful when the row and column
+    # names match (as they do for any correlation matrix). Refuse a square matrix
+    # with differing row/column names rather than silently mislabelling it.
+    if (!identical(rownames(corr), colnames(corr))) {
+      stop("A mixed layout requires the correlation matrix to have matching row ",
+           "and column names.", call. = FALSE)
+    }
+  }
+
   # Transform the correlation (and matching p-value) matrix into the long
   # data frames the plot is built from: reorder, round, mask a triangle, melt,
   # and join per-cell significance. Extracted so the mixed-method path can reuse
@@ -233,21 +300,52 @@ ggcorrplot <- function(corr,
   built <- .build_corr_df(
     corr = corr, p.mat = p.mat, type = type, show.diag = show.diag,
     hc.order = hc.order, hc.method = hc.method, digits = digits,
-    sig.level = sig.level, insig = insig, as.is = as.is
+    sig.level = sig.level,
+    # A mixed layout does not overlay significance, so the insig = "blank"
+    # value-zeroing must not run here: otherwise a "number" region would print a
+    # literal 0 for a non-significant cell instead of its coefficient. Force the
+    # non-blanking path when mixed so the numbers stay the true coefficients.
+    insig = if (mixed) "pch" else insig,
+    as.is = as.is
   )
   corr <- built$corr
   p.mat <- built$p.mat
 
   # heatmap
-  p <-
-    ggplot2::ggplot(
-      data = corr,
-      mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]], fill = .data[["value"]])
-    )
+  if (mixed) {
+    # Make the axis variables position-based factors before splitting into
+    # regions and drawing. reshape2::melt type-converts numeric-looking dimnames
+    # to their numeric VALUES (#37) and as.is = TRUE leaves them as strings; in
+    # both cases the region split (which keys off the grid POSITION) and the
+    # discrete axes would otherwise disagree and scramble the plot. Levels follow
+    # the melt (row) order, so for ordinary names this is the identity.
+    corr$Var1 <- factor(as.character(corr$Var1), levels = as.character(unique(corr$Var1)))
+    corr$Var2 <- factor(as.character(corr$Var2), levels = as.character(unique(corr$Var2)))
 
-  # modification based on method (extracted so the mixed-method path can request
-  # a different glyph per triangle from the same builder, P0.0)
-  p <- p + .method_layer(method, outline.color = outline.color, circle.scale = circle.scale)
+    # One glyph per region, each drawn from its own subset of the cells. The base
+    # plot carries no global fill so the text glyphs ("number"/"name") are not
+    # forced to inherit it; each glyph layer sets the aesthetics it needs.
+    p <- ggplot2::ggplot(
+      data = corr,
+      mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]])
+    )
+    p <- p + .mixed_layers(
+      corr, lower.method, upper.method,
+      outline.color = outline.color, circle.scale = circle.scale,
+      lab_size = lab_size, tl.cex = tl.cex, tl.col = tl.col,
+      digits = digits, nsmall = nsmall, leading.zero = leading.zero
+    )
+  } else {
+    p <-
+      ggplot2::ggplot(
+        data = corr,
+        mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]], fill = .data[["value"]])
+      )
+
+    # modification based on method (extracted so the mixed-method path can request
+    # a different glyph per triangle from the same builder, P0.0)
+    p <- p + .method_layer(method, outline.color = outline.color, circle.scale = circle.scale)
+  }
 
   # adding colors
   if (length(colors) < 2) {
@@ -272,6 +370,28 @@ ggcorrplot <- function(corr,
       limits = legend.limit,
       name = legend.title
     )
+  }
+
+  # A "number" region colours its text by the correlation value, so it needs a
+  # colour scale that matches the fill scale. When a square/circle region also
+  # draws fill, that fill scale carries the legend and the (redundant) colour
+  # guide is suppressed; when numbers are the ONLY value encoding (e.g. both
+  # triangles are "number"), the colour scale carries the legend instead, so the
+  # plot is never left legend-less.
+  if (mixed && "number" %in% c(lower.method, upper.method)) {
+    has_fill_glyph <- any(c(lower.method, upper.method) %in% c("square", "circle"))
+    colour_name <- if (has_fill_glyph) ggplot2::waiver() else legend.title
+    if (length(colors) == 3) {
+      p <- p + ggplot2::scale_colour_gradient2(
+        low = colors[1], high = colors[3], mid = colors[2],
+        midpoint = 0, limit = legend.limit, space = "Lab", name = colour_name
+      )
+    } else {
+      p <- p + ggplot2::scale_colour_gradientn(
+        colours = colors, limits = legend.limit, name = colour_name
+      )
+    }
+    if (has_fill_glyph) p <- p + ggplot2::guides(colour = "none")
   }
 
   # depending on the class of the object, add the specified theme
@@ -299,48 +419,49 @@ ggcorrplot <- function(corr,
     p <- p + ggplot2::coord_cartesian()
   }
 
-  label <- round(x = corr[, "value"], digits = digits)
-  if (nsmall > 0) label <- format(label, nsmall = nsmall, trim = TRUE)
-  if (!leading.zero) {
-    # drop the leading zero of values in (-1, 1), e.g. 0.23 -> .23, -0.67 -> -.67
-    # (idiom from @PawelKulawiak, #15). The \\b keeps values like 1.00 untouched.
-    label <- gsub("\\b0(\\.\\d+)", "\\1", label)
-  }
-  if (sig.stars && !is.null(p.mat)) {
-    stars <- as.character(cut(corr$pvalue,
-      breaks = c(-Inf, 0.001, 0.01, 0.05, Inf),
-      labels = c("***", "**", "*", "")
-    ))
-    stars[is.na(stars)] <- ""
-    label <- paste0(label, stars)
-  }
-  if (!is.null(p.mat) & insig == "blank") {
-    ns <- corr$pvalue > sig.level
-    ns[is.na(ns)] <- FALSE
-    if (sum(ns) > 0) label[ns] <- " "
-  }
+  # The coefficient-label overlay and the significance glyphs are single-method
+  # features. In a mixed layout the coefficients are a region glyph
+  # (method.* = "number") and significance is not overlaid, so this whole block
+  # is skipped; a non-mixed call runs it exactly as before.
+  if (!mixed) {
+    label <- .format_coef(corr[, "value"], digits = digits, nsmall = nsmall,
+                          leading.zero = leading.zero)
+    if (sig.stars && !is.null(p.mat)) {
+      stars <- as.character(cut(corr$pvalue,
+        breaks = c(-Inf, 0.001, 0.01, 0.05, Inf),
+        labels = c("***", "**", "*", "")
+      ))
+      stars[is.na(stars)] <- ""
+      label <- paste0(label, stars)
+    }
+    if (!is.null(p.mat) & insig == "blank") {
+      ns <- corr$pvalue > sig.level
+      ns[is.na(ns)] <- FALSE
+      if (sum(ns) > 0) label[ns] <- " "
+    }
 
-  # matrix cell labels
-  if (lab) {
-    p <- p +
-      ggplot2::geom_text(
+    # matrix cell labels
+    if (lab) {
+      p <- p +
+        ggplot2::geom_text(
+          mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),
+          label = label,
+          color = lab_col,
+          size = lab_size,
+          fontface = lab_fontface
+        )
+    }
+
+    # matrix cell glyphs
+    if (!is.null(p.mat) & insig == "pch" & !sig.stars) {
+      p <- p + ggplot2::geom_point(
+        data = p.mat,
         mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),
-        label = label,
-        color = lab_col,
-        size = lab_size,
-        fontface = lab_fontface
+        shape = pch,
+        size = pch.cex,
+        color = pch.col
       )
-  }
-
-  # matrix cell glyphs
-  if (!is.null(p.mat) & insig == "pch" & !sig.stars) {
-    p <- p + ggplot2::geom_point(
-      data = p.mat,
-      mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),
-      shape = pch,
-      size = pch.cex,
-      color = pch.col
-    )
+    }
   }
 
   # add titles
@@ -553,6 +674,97 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
       ggplot2::guides(size = "none")
     )
   }
+}
+
+# Format the correlation coefficients for display: round to `digits`, optionally
+# pad to `nsmall` decimals, optionally drop the leading zero. Shared by the
+# single-method label overlay and the mixed "number" glyph so they format the
+# same way.
+.format_coef <- function(x, digits, nsmall, leading.zero) {
+  label <- round(x = x, digits = digits)
+  if (nsmall > 0) label <- format(label, nsmall = nsmall, trim = TRUE)
+  if (!leading.zero) {
+    # drop the leading zero of values in (-1, 1), e.g. 0.23 -> .23, -0.67 -> -.67
+    # (idiom from @PawelKulawiak, #15). The \\b keeps values like 1.00 untouched.
+    label <- gsub("\\b0(\\.\\d+)", "\\1", label)
+  }
+  label
+}
+
+# Build the layers for a mixed layout: a per-triangle glyph over the lower
+# triangle (Var1 index > Var2 index) and the upper triangle, plus the variable
+# names on the diagonal. Each region is a subset of the melted correlation data
+# frame drawn with its own layer so the glyphs can differ. "square"/"circle" draw
+# the usual glyphs; "number" draws the coefficient as text colored by value
+# (matched by a colour scale added in the caller); the diagonal always draws the
+# variable name. Returns a list of ggplot components.
+.mixed_layers <- function(df, lower.method, upper.method,
+                          outline.color, circle.scale, lab_size, tl.cex, tl.col,
+                          digits, nsmall, leading.zero) {
+  xi <- as.integer(df$Var1)
+  yi <- as.integer(df$Var2)
+  regions <- list(
+    list(data = df[xi > yi, , drop = FALSE], method = lower.method),
+    list(data = df[xi < yi, , drop = FALSE], method = upper.method),
+    list(data = df[xi == yi, , drop = FALSE], method = "name")
+  )
+
+  layers <- list()
+  has_circle <- FALSE
+  for (r in regions) {
+    d <- r$data
+    if (nrow(d) == 0) next
+    m <- r$method
+    if (m == "square") {
+      layers <- c(layers, list(ggplot2::geom_tile(
+        data = d,
+        mapping = ggplot2::aes(fill = .data[["value"]]),
+        color = outline.color
+      )))
+    } else if (m == "circle") {
+      has_circle <- TRUE
+      layers <- c(layers, list(ggplot2::geom_point(
+        data = d,
+        mapping = ggplot2::aes(fill = .data[["value"]], size = .data[["abs_corr"]]),
+        color = outline.color, shape = 21
+      )))
+    } else if (m == "number") {
+      layers <- c(layers, list(ggplot2::geom_text(
+        data = d,
+        mapping = ggplot2::aes(colour = .data[["value"]]),
+        label = .format_coef(d$value, digits, nsmall, leading.zero),
+        size = lab_size
+      )))
+    } else if (m == "name") {
+      layers <- c(layers, list(ggplot2::geom_text(
+        data = d,
+        mapping = ggplot2::aes(label = .data[["Var1"]]),
+        colour = if (is.null(tl.col)) "black" else tl.col,
+        size = tl.cex / 3
+      )))
+    }
+  }
+
+  if (has_circle) {
+    layers <- c(layers, list(
+      ggplot2::scale_size(range = c(4, 10) * circle.scale),
+      ggplot2::guides(size = "none")
+    ))
+  }
+
+  # Each region is a separate layer over a subset of the cells, so a variable
+  # absent from one region's subset (e.g. the first variable never appears in the
+  # lower triangle) would otherwise make ggplot infer that axis's order from the
+  # cells it does see, misaligning the two axes and bending the diagonal. Pin both
+  # axes to the full variable order so every cell lands on the shared grid.
+  lvls_x <- if (is.factor(df$Var1)) levels(df$Var1) else unique(as.character(df$Var1))
+  lvls_y <- if (is.factor(df$Var2)) levels(df$Var2) else unique(as.character(df$Var2))
+  layers <- c(layers, list(
+    ggplot2::scale_x_discrete(limits = lvls_x, drop = FALSE),
+    ggplot2::scale_y_discrete(limits = lvls_y, drop = FALSE)
+  ))
+
+  layers
 }
 
 # Get lower triangle of the correlation matrix

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -40,7 +40,9 @@ ggcorrplot(
   leading.zero = TRUE,
   legend.limit = c(-1, 1),
   circle.scale = 1,
-  coord.fixed = TRUE
+  coord.fixed = TRUE,
+  lower.method = NULL,
+  upper.method = NULL
 )
 
 cor_pmat(x, ..., use = c("pairwise.complete.obs", "everything"))
@@ -51,7 +53,20 @@ cor_pmat(x, ..., use = c("pairwise.complete.obs", "everything"))
 \item{method}{character, the visualization method of correlation matrix to be
 used. Allowed values are "square" (default), "circle".}
 
-\item{type}{character, "full" (default), "lower" or "upper" display.}
+\item{lower.method, upper.method}{character, an optional per-triangle glyph for
+a mixed layout: one of "square", "circle" or "number" (the coefficient drawn
+as text, colored by its value on the same scale as the fill, so coefficients
+near zero are faint). When either is set, the plot switches to a mixed layout
+where the lower and upper triangles are drawn separately and the variable names
+are drawn on the diagonal; a triangle left \code{NULL} uses \code{method}. Both
+default to \code{NULL} (single-method plot, unchanged). In a mixed layout the
+single-method significance and label overlays (\code{lab}, \code{sig.stars},
+\code{p.mat}, \code{insig}, \code{pch*}) do not apply; show coefficients with a
+"number" triangle instead.}
+
+\item{type}{character, "full" (default), "lower" or "upper" display. A mixed
+layout (see \code{lower.method}/\code{upper.method}) always uses the full
+matrix.}
 
 \item{ggtheme}{ggplot2 function or theme object. Default value is
 `theme_minimal`. Allowed values are the official ggplot2 themes including
@@ -173,26 +188,26 @@ corresponding values of \code{\link[stats]{cor}}'s \code{use} argument.}
 \itemize{ \item ggcorrplot(): Returns a ggplot2 \item cor_pmat():
 Returns a matrix containing the p-values of correlations }
 }
-\details{
-\code{cor_pmat()} tests each pair of columns with
-\code{\link[stats]{cor.test}}. A pair with fewer than three overlapping
-non-missing observations (which \code{\link[stats]{cor.test}} cannot test,
-e.g. two variables that never co-occur) yields \code{NA} for that cell
-rather than aborting the whole computation. Pairs that can be tested are
-computed as before, and errors they raise are passed through.
-
-The \code{use} argument controls which pairs are returned as \code{NA} so
-the p-value matrix can be aligned with a correlation matrix built the same
-way. With the default \code{"pairwise.complete.obs"} every pair that has
-enough overlapping observations is tested (the previous behavior). With
-\code{"everything"} a pair is set to \code{NA} whenever either variable has
-any missing value, so the \code{NA} pattern matches
-\code{\link[stats]{cor}(x)} with its default \code{use = "everything"}.
-}
 \description{
 \itemize{ \item ggcorrplot(): A graphical display of a
   correlation matrix using ggplot2. \item cor_pmat(): Compute a correlation
   matrix p-values. }
+}
+\details{
+\code{cor_pmat()} tests each pair of columns with
+  \code{\link[stats]{cor.test}}. A pair with fewer than three overlapping
+  non-missing observations (which \code{\link[stats]{cor.test}} cannot test,
+  e.g. two variables that never co-occur) yields \code{NA} for that cell
+  rather than aborting the whole computation. Pairs that can be tested are
+  computed as before, and errors they raise are passed through.
+
+  The \code{use} argument controls which pairs are returned as \code{NA} so
+  the p-value matrix can be aligned with a correlation matrix built the same
+  way. With the default \code{"pairwise.complete.obs"} every pair that has
+  enough overlapping observations is tested (the previous behavior). With
+  \code{"everything"} a pair is set to \code{NA} whenever either variable has
+  any missing value, so the \code{NA} pattern matches
+  \code{\link[stats]{cor}(x)} with its default \code{use = "everything"}.
 }
 \examples{
 # Compute a correlation matrix
@@ -209,6 +224,14 @@ p.mat
 # method = "square" or "circle"
 ggcorrplot(corr)
 ggcorrplot(corr, method = "circle")
+
+# Mixed layout: a different glyph per triangle
+# --------------------------------
+# numbers in the lower triangle, circles in the upper, names on the diagonal
+ggcorrplot(corr,
+  lower.method = "number", upper.method = "circle",
+  show.legend = FALSE
+)
 
 # Reordering the correlation matrix
 # --------------------------------

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-mixed.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-mixed.svg
@@ -1,0 +1,207 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODAuNzR8NjM5LjI2fDAuMDB8NTc2LjAw'>
+    <rect x='80.74' y='0.00' width='558.52' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODAuNzR8NjM5LjI2fDAuMDB8NTc2LjAw)'>
+<rect x='80.74' y='0.00' width='558.52' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTE2LjUxfDYzMy43OHwyMi43OHw1NDAuMDY='>
+    <rect x='116.51' y='22.78' width='517.27' height='517.27' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTE2LjUxfDYzMy43OHwyMi43OHw1NDAuMDY=)'>
+<polyline points='116.51,512.35 633.78,512.35 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,466.16 633.78,466.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,419.98 633.78,419.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,373.79 633.78,373.79 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,327.61 633.78,327.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,281.42 633.78,281.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,235.24 633.78,235.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,189.05 633.78,189.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,142.86 633.78,142.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,96.68 633.78,96.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='116.51,50.49 633.78,50.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='144.22,540.06 144.22,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='190.40,540.06 190.40,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='236.59,540.06 236.59,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='282.77,540.06 282.77,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='328.96,540.06 328.96,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='375.14,540.06 375.14,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='421.33,540.06 421.33,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='467.52,540.06 467.52,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='513.70,540.06 513.70,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='559.89,540.06 559.89,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='606.07,540.06 606.07,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<text x='190.40' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #502BFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.9</text>
+<text x='236.59' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #7145FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='282.77' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #7145FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='328.96' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #FF7352; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='375.14' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #502BFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.9</text>
+<text x='421.33' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #FFB299; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='467.52' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #FF7352; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='513.70' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #FF8969; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='559.89' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #FF9E81; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='606.07' y='516.26' text-anchor='middle' style='font-size: 11.38px; fill: #A074FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='236.59' y='470.08' text-anchor='middle' style='font-size: 11.38px; fill: #FF3E22; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='282.77' y='470.08' text-anchor='middle' style='font-size: 11.38px; fill: #FF5B3A; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='328.96' y='470.08' text-anchor='middle' style='font-size: 11.38px; fill: #8A5DFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='375.14' y='470.08' text-anchor='middle' style='font-size: 11.38px; fill: #FF5B3A; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='421.33' y='470.08' text-anchor='middle' style='font-size: 11.38px; fill: #A074FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='467.52' y='470.08' text-anchor='middle' style='font-size: 11.38px; fill: #7145FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='513.70' y='470.08' text-anchor='middle' style='font-size: 11.38px; fill: #B38BFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='559.89' y='470.08' text-anchor='middle' style='font-size: 11.38px; fill: #B38BFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='606.07' y='470.08' text-anchor='middle' style='font-size: 11.38px; fill: #FF9E81; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='282.77' y='423.89' text-anchor='middle' style='font-size: 11.38px; fill: #FF5B3A; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='328.96' y='423.89' text-anchor='middle' style='font-size: 11.38px; fill: #8A5DFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='375.14' y='423.89' text-anchor='middle' style='font-size: 11.38px; fill: #FF3E22; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='421.33' y='423.89' text-anchor='middle' style='font-size: 11.38px; fill: #C4A2FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.4</text>
+<text x='467.52' y='423.89' text-anchor='middle' style='font-size: 11.38px; fill: #8A5DFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='513.70' y='423.89' text-anchor='middle' style='font-size: 11.38px; fill: #A074FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='559.89' y='423.89' text-anchor='middle' style='font-size: 11.38px; fill: #A074FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='606.07' y='423.89' text-anchor='middle' style='font-size: 11.38px; fill: #FFB299; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='328.96' y='377.71' text-anchor='middle' style='font-size: 11.38px; fill: #C4A2FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.4</text>
+<text x='375.14' y='377.71' text-anchor='middle' style='font-size: 11.38px; fill: #FF7352; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='421.33' y='377.71' text-anchor='middle' style='font-size: 11.38px; fill: #8A5DFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='467.52' y='377.71' text-anchor='middle' style='font-size: 11.38px; fill: #8A5DFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='513.70' y='377.71' text-anchor='middle' style='font-size: 11.38px; fill: #E3D0FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='559.89' y='377.71' text-anchor='middle' style='font-size: 11.38px; fill: #F2E7FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.1</text>
+<text x='606.07' y='377.71' text-anchor='middle' style='font-size: 11.38px; fill: #FF7352; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='375.14' y='331.52' text-anchor='middle' style='font-size: 11.38px; fill: #8A5DFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='421.33' y='331.52' text-anchor='middle' style='font-size: 11.38px; fill: #FFECE5; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='467.52' y='331.52' text-anchor='middle' style='font-size: 11.38px; fill: #FFB299; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='513.70' y='331.52' text-anchor='middle' style='font-size: 11.38px; fill: #FF7352; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='559.89' y='331.52' text-anchor='middle' style='font-size: 11.38px; fill: #FF7352; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='606.07' y='331.52' text-anchor='middle' style='font-size: 11.38px; fill: #F2E7FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.1</text>
+<text x='421.33' y='285.34' text-anchor='middle' style='font-size: 11.38px; fill: #E3D0FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='467.52' y='285.34' text-anchor='middle' style='font-size: 11.38px; fill: #A074FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='513.70' y='285.34' text-anchor='middle' style='font-size: 11.38px; fill: #8A5DFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='559.89' y='285.34' text-anchor='middle' style='font-size: 11.38px; fill: #A074FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='606.07' y='285.34' text-anchor='middle' style='font-size: 11.38px; fill: #FFB299; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='467.52' y='239.15' text-anchor='middle' style='font-size: 11.38px; fill: #FF7352; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='513.70' y='239.15' text-anchor='middle' style='font-size: 11.38px; fill: #E3D0FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='559.89' y='239.15' text-anchor='middle' style='font-size: 11.38px; fill: #E3D0FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='606.07' y='239.15' text-anchor='middle' style='font-size: 11.38px; fill: #8A5DFF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='513.70' y='192.97' text-anchor='middle' style='font-size: 11.38px; fill: #FFD9CB; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='559.89' y='192.97' text-anchor='middle' style='font-size: 11.38px; fill: #FFD9CB; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='606.07' y='192.97' text-anchor='middle' style='font-size: 11.38px; fill: #A074FF; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='559.89' y='146.78' text-anchor='middle' style='font-size: 11.38px; fill: #FF5B3A; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='606.07' y='146.78' text-anchor='middle' style='font-size: 11.38px; fill: #FFECE5; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='606.07' y='100.60' text-anchor='middle' style='font-size: 11.38px; fill: #FFC6B2; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<circle cx='144.22' cy='466.16' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #502BFF;' />
+<circle cx='144.22' cy='419.98' r='10.61' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #7145FF;' />
+<circle cx='190.40' cy='419.98' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF3E22;' />
+<circle cx='144.22' cy='373.79' r='10.61' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #7145FF;' />
+<circle cx='190.40' cy='373.79' r='10.61' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='236.59' cy='373.79' r='10.61' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='144.22' cy='327.61' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='190.40' cy='327.61' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='236.59' cy='327.61' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='282.77' cy='327.61' r='8.54' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #C4A2FF;' />
+<circle cx='144.22' cy='281.42' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #502BFF;' />
+<circle cx='190.40' cy='281.42' r='10.61' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='236.59' cy='281.42' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF3E22;' />
+<circle cx='282.77' cy='281.42' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='328.96' cy='281.42' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='144.22' cy='235.24' r='8.54' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='190.40' cy='235.24' r='9.68' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='236.59' cy='235.24' r='8.54' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #C4A2FF;' />
+<circle cx='282.77' cy='235.24' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='328.96' cy='235.24' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFECE5;' />
+<circle cx='375.14' cy='235.24' r='6.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='144.22' cy='189.05' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='190.40' cy='189.05' r='10.61' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #7145FF;' />
+<circle cx='236.59' cy='189.05' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='282.77' cy='189.05' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='328.96' cy='189.05' r='8.54' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='375.14' cy='189.05' r='9.68' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='421.33' cy='189.05' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='144.22' cy='142.86' r='9.68' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF8969;' />
+<circle cx='190.40' cy='142.86' r='9.15' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #B38BFF;' />
+<circle cx='236.59' cy='142.86' r='9.68' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='282.77' cy='142.86' r='6.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='328.96' cy='142.86' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='375.14' cy='142.86' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='421.33' cy='142.86' r='6.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='467.52' cy='142.86' r='6.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFD9CB;' />
+<circle cx='144.22' cy='96.68' r='9.15' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF9E81;' />
+<circle cx='190.40' cy='96.68' r='9.15' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #B38BFF;' />
+<circle cx='236.59' cy='96.68' r='9.68' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='282.77' cy='96.68' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #F2E7FF;' />
+<circle cx='328.96' cy='96.68' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='375.14' cy='96.68' r='9.68' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='421.33' cy='96.68' r='6.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='467.52' cy='96.68' r='6.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFD9CB;' />
+<circle cx='513.70' cy='96.68' r='10.61' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='144.22' cy='50.49' r='9.68' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='190.40' cy='50.49' r='9.15' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF9E81;' />
+<circle cx='236.59' cy='50.49' r='8.54' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='282.77' cy='50.49' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='328.96' cy='50.49' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #F2E7FF;' />
+<circle cx='375.14' cy='50.49' r='8.54' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='421.33' cy='50.49' r='10.17' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='467.52' cy='50.49' r='9.68' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='513.70' cy='50.49' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFECE5;' />
+<circle cx='559.89' cy='50.49' r='7.82' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFC6B2;' />
+<text x='144.22' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='190.40' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.92px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='236.59' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='20.88px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='282.77' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='12.66px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text x='328.96' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='375.14' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='11.38px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text x='421.33' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='24.05px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text x='467.52' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='11.39px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text x='513.70' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text x='559.89' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.78px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text x='606.07' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='22.15px' lengthAdjust='spacingAndGlyphs'>carb</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='111.58' y='516.47' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='111.58' y='470.29' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='111.58' y='424.10' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='111.58' y='377.92' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text x='111.58' y='331.73' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='111.58' y='285.55' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text x='111.58' y='239.36' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text x='111.58' y='193.18' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text x='111.58' y='146.99' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text x='111.58' y='100.81' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text x='111.58' y='54.62' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text transform='translate(150.06,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text transform='translate(196.24,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text transform='translate(242.43,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(288.61,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text transform='translate(334.80,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text transform='translate(380.98,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(427.17,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text transform='translate(473.35,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text transform='translate(519.54,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text transform='translate(565.73,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text transform='translate(611.91,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text x='116.51' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='143.80px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - mixed</text>
+</g>
+</svg>

--- a/tests/testthat/test-mixed.R
+++ b/tests/testthat/test-mixed.R
@@ -1,0 +1,197 @@
+# Mixed layout (P0.1, issue #85): a different glyph per triangle, requested via
+# lower.method / upper.method; the diagonal always shows the variable names. The
+# single-method path must stay byte-identical (that is covered by test-structure.R
+# and the byte-identity harness); here we lock the structure of the mixed plot.
+
+corr <- round(cor(mtcars), 1)
+p.mat <- cor_pmat(mtcars)
+n <- ncol(mtcars)
+tri <- n * (n - 1) / 2
+
+geoms <- function(p) unname(vapply(p$layers, function(l) class(l$geom)[1], character(1)))
+has_scale <- function(p, aes) {
+  any(vapply(p$scales$scales, function(s) aes %in% s$aesthetics, logical(1)))
+}
+axis_labels <- function(p, which) {
+  b <- ggplot2::ggplot_build(p)
+  b$layout$panel_params[[1]][[which]]$get_labels()
+}
+
+test_that("no method.* argument leaves the single-method path untouched", {
+  # mixed mode must NOT fire when the per-region args are absent
+  base <- ggcorrplot(corr)
+  expect_equal(geoms(base), "GeomTile")
+  expect_false(has_scale(base, "colour"))
+})
+
+test_that("lower.method + upper.method draws a glyph per triangle plus a name diagonal", {
+  p <- ggcorrplot(corr, lower.method = "number", upper.method = "circle")
+  # lower numbers (text), upper circles (points), diagonal names (text)
+  expect_equal(geoms(p), c("GeomText", "GeomPoint", "GeomText"))
+  # each region holds the right number of cells
+  rows <- vapply(ggplot2::ggplot_build(p)$data, nrow, integer(1))
+  expect_equal(sort(rows), sort(c(tri, tri, n))) # two triangles + diagonal
+})
+
+test_that("the two axes share one variable order so the diagonal is a straight line", {
+  p <- ggcorrplot(corr, lower.method = "number", upper.method = "circle")
+  expect_identical(axis_labels(p, "x"), axis_labels(p, "y"))
+  expect_identical(axis_labels(p, "x"), colnames(corr))
+})
+
+test_that("a 'number' region adds a colour scale with its guide suppressed", {
+  p <- ggcorrplot(corr, lower.method = "number", upper.method = "circle")
+  expect_true(has_scale(p, "colour"))
+  # the fill scale (from the circle region) is still present for the legend
+  expect_true(has_scale(p, "fill"))
+})
+
+test_that("a numbers-only mixed plot keeps a legend for its value colours", {
+  colour_scale <- function(p) {
+    s <- p$scales$scales
+    s[[which(vapply(s, function(x) "colour" %in% x$aesthetics, logical(1)))]]
+  }
+  # both triangles numeric: no fill glyph, so the colour scale must carry the
+  # legend (named), otherwise the plot would be colour-encoded but legend-less
+  nn <- ggcorrplot(corr, lower.method = "number", upper.method = "number")
+  expect_equal(colour_scale(nn)$name, "Corr")
+  # a fill glyph present: the fill scale carries the legend, colour is redundant
+  nc <- ggcorrplot(corr, lower.method = "number", upper.method = "circle")
+  expect_s3_class(colour_scale(nc)$name, "waiver")
+})
+
+test_that("no 'number' region means no colour scale", {
+  p <- ggcorrplot(corr, lower.method = "square", upper.method = "circle")
+  expect_false(has_scale(p, "colour"))
+  expect_equal(geoms(p), c("GeomTile", "GeomPoint", "GeomText"))
+})
+
+test_that("the diagonal shows the variable names in a mixed layout", {
+  p <- ggcorrplot(corr, lower.method = "square", upper.method = "circle")
+  # the last layer is the diagonal name text, one per variable
+  diag_layer <- p$layers[[length(p$layers)]]
+  expect_s3_class(diag_layer$geom, "GeomText")
+  d <- diag_layer$data
+  expect_equal(nrow(d), n)
+  expect_true(all(as.character(d$Var1) == as.character(d$Var2)))
+})
+
+test_that("an unset triangle inherits the base method", {
+  p <- ggcorrplot(corr, upper.method = "circle") # method defaults to square
+  # lower triangle should be squares (tiles), upper circles, diagonal names
+  expect_true(all(c("GeomTile", "GeomPoint") %in% geoms(p)))
+})
+
+test_that("mixed mode forces the full matrix regardless of type", {
+  p <- ggcorrplot(corr, lower.method = "number", upper.method = "circle", type = "lower")
+  rows <- sum(vapply(ggplot2::ggplot_build(p)$data, nrow, integer(1)))
+  expect_equal(rows, n * n) # full matrix, not just a triangle
+})
+
+test_that("mixed labels format like the coefficient labels do", {
+  # the number glyph reuses .format_coef, so nsmall / leading.zero apply
+  p <- ggcorrplot(corr, lower.method = "number", nsmall = 2L)
+  lower <- ggplot2::ggplot_build(p)$data[[1]]
+  expect_true(all(grepl("\\.[0-9]{2}$", lower$label)))
+})
+
+test_that("a mixed layout requires a square matrix", {
+  ns <- cor(mtcars)[1:3, 1:5]
+  expect_error(ggcorrplot(ns, lower.method = "number"), "square")
+})
+
+test_that("a mixed layout requires matching row and column names (no silent mislabel)", {
+  m <- round(cor(mtcars[, 1:4]), 1)
+  colnames(m) <- c("w", "x", "y", "z") # square, but names differ from rownames
+  expect_error(
+    ggcorrplot(m, lower.method = "number", upper.method = "circle"),
+    "matching row and column names"
+  )
+  # a genuine correlation matrix (rownames == colnames) is unaffected
+  expect_s3_class(
+    ggplot2::ggplotGrob(ggcorrplot(round(cor(mtcars[, 1:4]), 1),
+      lower.method = "number", upper.method = "circle"
+    )),
+    "gtable"
+  )
+})
+
+test_that("per-triangle methods are validated", {
+  expect_error(ggcorrplot(corr, lower.method = "pie"))
+  expect_error(ggcorrplot(corr, upper.method = "wedge"))
+})
+
+test_that("a number region shows the true coefficient, never a blanked 0, under insig='blank'", {
+  # regression: the shared insig='blank' zeroing must not reach the number glyph,
+  # or non-significant cells would print a wrong "0" instead of their coefficient
+  suppressMessages(
+    p <- ggcorrplot(corr,
+      lower.method = "number", upper.method = "circle",
+      p.mat = p.mat, insig = "blank"
+    )
+  )
+  lower <- ggplot2::ggplot_build(p)$data[[1]]
+  expect_false(any(lower$label == "0"))
+  # the labels are the real rounded coefficients
+  expect_true(all(grepl("^-?[01]?\\.[0-9]+$|^-?1$", lower$label)))
+})
+
+test_that("mixed mode messages when it ignores single-method overlay arguments", {
+  expect_message(
+    ggcorrplot(corr, lower.method = "number", p.mat = p.mat),
+    "mixed layout"
+  )
+  expect_message(
+    ggcorrplot(corr, lower.method = "number", lab = TRUE),
+    "mixed layout"
+  )
+  # no message for a clean mixed call that sets no overlay arguments
+  expect_no_message(
+    ggcorrplot(corr, lower.method = "number", upper.method = "circle")
+  )
+})
+
+test_that("numeric-looking, non-sorted dimnames do not scramble the mixed grid (#37)", {
+  # reshape2::melt type-converts numeric names to their VALUES; the region split
+  # and axes must key off grid POSITION, not the value, or the diagonal bends
+  m <- round(cor(mtcars[, 1:5]), 1)
+  dimnames(m) <- list(c("50", "10", "30", "20", "40"), c("50", "10", "30", "20", "40"))
+  p <- ggcorrplot(m, lower.method = "number", upper.method = "circle")
+  # the axes keep the matrix order (not sorted numerically)
+  expect_identical(axis_labels(p, "x"), c("50", "10", "30", "20", "40"))
+  expect_identical(axis_labels(p, "x"), axis_labels(p, "y"))
+  # the diagonal "name" cells sit exactly on x == y
+  b <- ggplot2::ggplot_build(p)
+  diag_d <- p$layers[[3]]$data
+  xpos <- match(as.character(diag_d$Var1), axis_labels(p, "x"))
+  ypos <- match(as.character(diag_d$Var2), axis_labels(p, "y"))
+  expect_equal(xpos, ypos)
+})
+
+test_that("as.is = TRUE works in a mixed layout without warning or scrambling", {
+  m <- round(cor(mtcars[, 1:5]), 1)
+  expect_no_warning(
+    p <- ggcorrplot(m, lower.method = "number", upper.method = "circle", as.is = TRUE)
+  )
+  k <- ncol(m)
+  rows <- sort(vapply(ggplot2::ggplot_build(p)$data, nrow, integer(1)))
+  expect_equal(rows, sort(c(k, k * (k - 1) / 2, k * (k - 1) / 2)))
+})
+
+test_that("the mixed arguments do not break partial matching of existing arguments", {
+  # lower.method/upper.method deliberately avoid the prefixes of commonly-used
+  # existing arguments, so their abbreviations keep resolving uniquely:
+  # `meth`/`m` still reach `method`, and `d`/`di` still reach `digits`.
+  expect_s3_class(ggcorrplot(corr, meth = "circle")$layers[[1]]$geom, "GeomPoint")
+  expect_s3_class(ggcorrplot(corr, m = "circle")$layers[[1]]$geom, "GeomPoint")
+  # `digits` abbreviations must still work (no `diag.*` formal shadows them)
+  expect_silent(ggcorrplot(corr, d = 2))
+  expect_silent(ggcorrplot(corr, di = 2))
+})
+
+test_that("mixed composes with hc.order without error and stays full", {
+  p <- ggcorrplot(corr, lower.method = "number", upper.method = "circle", hc.order = TRUE)
+  expect_s3_class(ggplot2::ggplotGrob(p), "gtable")
+  # reordered axis is still shared between x and y
+  expect_identical(axis_labels(p, "x"), axis_labels(p, "y"))
+})

--- a/tests/testthat/test-structure.R
+++ b/tests/testthat/test-structure.R
@@ -33,6 +33,16 @@ test_that("the default plot is a single tile layer over every cell", {
   expect_equal(layer_rows(p), n * n)
 })
 
+test_that("positional arguments still bind as before (new args are appended, not inserted)", {
+  # the mixed-layout args were added at the END of the signature, so a positional
+  # `type` call must keep working: ggcorrplot(corr, <method>, <type>)
+  p <- ggcorrplot(corr, "circle", "lower")
+  expect_equal(geoms(p), "GeomPoint")
+  expect_equal(layer_rows(p), n * (n - 1) / 2) # lower triangle, off-diagonal
+  full <- ggcorrplot(corr, "circle", "full")
+  expect_equal(layer_rows(full), n * n)
+})
+
 test_that("method = 'circle' swaps the tile layer for a sized point layer", {
   p <- ggcorrplot(corr, method = "circle")
   expect_equal(geoms(p), "GeomPoint")

--- a/tests/testthat/test-vdiffr.R
+++ b/tests/testthat/test-vdiffr.R
@@ -28,5 +28,14 @@ if (getRversion() >= "4.1") {
       title = "ggcorrplot works - hc",
       fig = ggcorrplot(corr, hc.order = TRUE, outline.color = "white")
     )
+
+    set.seed(123)
+    vdiffr::expect_doppelganger(
+      title = "ggcorrplot works - mixed",
+      fig = ggcorrplot(corr,
+        lower.method = "number", upper.method = "circle",
+        show.legend = FALSE
+      )
+    )
   })
 }


### PR DESCRIPTION
Adds a mixed layout to `ggcorrplot()` — a different glyph per triangle — via two new arguments:

- `lower.method`, `upper.method` — `"square"`, `"circle"` or `"number"` (the coefficient drawn as text, colored by value). Setting either switches to a mixed layout; a triangle left `NULL` uses the base `method`. The variable names are drawn on the diagonal.

```r
ggcorrplot(round(cor(mtcars), 1), lower.method = "number", upper.method = "circle")
```

Both default to `NULL`, so any call that sets neither takes the unchanged single-method path and its output is byte-identical (verified across the full argument-combination fingerprint — including positional cases — and the visual snapshots).

Non-regression details:
- The two arguments are appended at the **end** of the signature (positional binding of existing arguments is unchanged) and named to avoid shadowing the abbreviations of existing arguments — `method` (`meth=`) and `digits` (`d=`, `di=`) still resolve uniquely (test-locked).
- The axis variables are made position-based factors, so numeric-looking dimnames or `as.is = TRUE` cannot scramble the grid.
- In a mixed layout the single-method overlays (`lab`, `sig.stars`, `p.mat`, `insig`, `pch*`) do not apply — coefficients are a triangle glyph — so `insig = "blank"` never turns a coefficient into a misleading `0`, and a `message()` notes when such an argument is ignored.

Adds `test-mixed.R` (structure, numeric-name and `as.is` handling, positional/partial-matching non-regression) and a mixed vdiffr snapshot; the single-method tests and snapshots are unchanged. Closes #85.
