### PR TITLE
Add hc.rect to draw rectangles around clusters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@
   accepts "square", "circle" or "number"; both default to `NULL`, leaving the
   single-method output unchanged (#85). Requested by @Breeze-Hu.
 
+- New argument `hc.rect` to draw rectangles around the clusters of a
+  hierarchically-ordered correlogram: `ggcorrplot(corr, hc.order = TRUE,
+  hc.rect = 3)` frames the 3 clusters obtained by cutting the tree. Defaults to
+  `NULL` (no rectangles).
+
 ## Minor changes
 
 - Internal refactor: the data-preparation pipeline and the glyph-layer

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -42,6 +42,13 @@
 #' @param hc.order logical value. If TRUE, correlation matrix will be hc.ordered
 #'   using hclust function.
 #' @param hc.method the agglomeration method to be used in hclust (see ?hclust).
+#' @param hc.rect integer or \code{NULL} (default). If an integer \code{k}, draws
+#'   \code{k} rectangles (fixed style: grey outline, no fill) around the clusters
+#'   obtained by cutting the hierarchical tree, marking the cluster blocks on the
+#'   diagonal. Requires \code{hc.order = TRUE} and \code{type = "full"} (the boxes
+#'   span whole diagonal blocks). \code{NULL} (default) draws no rectangles. For a
+#'   custom box style, add your own \code{annotate("rect", ...)} to the returned
+#'   plot.
 #' @param lab logical value. If TRUE, add correlation coefficient on the plot.
 #' @param lab_col,lab_size size and color to be used for the correlation
 #'   coefficient labels. used when lab = TRUE.
@@ -127,6 +134,8 @@
 #' # --------------------------------
 #' # using hierarchical clustering
 #' ggcorrplot(corr, hc.order = TRUE, outline.color = "white")
+#' # draw rectangles around the clusters
+#' ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, outline.color = "white")
 #'
 #' # Types of correlogram layout
 #' # --------------------------------
@@ -223,7 +232,8 @@ ggcorrplot <- function(corr,
                        circle.scale = 1,
                        coord.fixed = TRUE,
                        lower.method = NULL,
-                       upper.method = NULL) {
+                       upper.method = NULL,
+                       hc.rect = NULL) {
   type <- match.arg(type)
   method <- match.arg(method)
   insig <- match.arg(insig)
@@ -310,6 +320,7 @@ ggcorrplot <- function(corr,
   )
   corr <- built$corr
   p.mat <- built$p.mat
+  hc <- built$hc
 
   # heatmap
   if (mixed) {
@@ -464,6 +475,50 @@ ggcorrplot <- function(corr,
     }
   }
 
+  # cluster rectangles: draw hc.rect boxes around the k clusters obtained by
+  # cutting the dendrogram. Requires hc.order (so the variables are in dendrogram
+  # order and each cluster is a contiguous block). The blocks are full squares on
+  # the diagonal, so they are only meaningful on the full matrix -- on a lower/
+  # upper triangle a box would extend over the blanked half. Added on top of the
+  # glyphs.
+  if (!is.null(hc.rect)) {
+    if (!hc.order) {
+      stop("hc.rect requires hc.order = TRUE.", call. = FALSE)
+    }
+    if (type != "full") {
+      stop("hc.rect requires type = \"full\"; the cluster boxes span the whole ",
+           "diagonal block and would extend over the hidden triangle otherwise.",
+           call. = FALSE)
+    }
+    # The box positions are grid indices 1..n in dendrogram order, so they only
+    # line up with the cells when the axis is the discrete factor melt() produced
+    # in that order. Numeric-looking dimnames (type-converted to a continuous axis
+    # sorted by value) or as.is = TRUE (a character axis sorted alphabetically)
+    # reorder the axis away from the clustering, which would draw the boxes over
+    # the wrong cells -- refuse rather than mislead.
+    if (!is.factor(corr$Var1)) {
+      stop("hc.rect is not supported with numeric-looking dimnames or ",
+           "as.is = TRUE, which order the axis by name rather than by the ",
+           "clustering; use non-numeric variable names.", call. = FALSE)
+    }
+    k <- hc.rect
+    n <- length(hc$order)
+    if (!is.numeric(k) || length(k) != 1L || is.na(k) || k < 1 || k > n ||
+        k != as.integer(k)) {
+      stop("hc.rect must be a single integer between 1 and ", n,
+           " (the number of variables).", call. = FALSE)
+    }
+    b <- .hc_rect_bounds(hc, k)
+    # No linewidth/size: the default border keeps this compatible with the
+    # declared ggplot2 floor (linewidth is a ggplot2 >= 3.4.0 aesthetic).
+    p <- p + ggplot2::annotate(
+      "rect",
+      xmin = b$lo - 0.5, xmax = b$hi + 0.5,
+      ymin = b$lo - 0.5, ymax = b$hi + 0.5,
+      fill = NA, colour = "gray30"
+    )
+  }
+
   # add titles
   if (title != "") {
     p <- p +
@@ -595,8 +650,10 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
 
   # Order on the unrounded matrix so the internal rounding below does not
   # introduce ties that perturb the hierarchical clustering (#14).
+  hc <- NULL
   if (hc.order) {
-    ord <- .hc_cormat_order(corr, hc.method = hc.method)
+    hc <- .hc_cormat_order(corr, hc.method = hc.method)
+    ord <- hc$order
     corr <- corr[ord, ord]
     if (!is.null(p.mat)) {
       p.mat <- p.mat[ord, ord]
@@ -654,7 +711,8 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
 
   corr$abs_corr <- abs(corr$value) * 10
 
-  list(corr = corr, p.mat = p.mat)
+  # `hc` is the hclust object when hc.order = TRUE (needed for hc.rect), else NULL.
+  list(corr = corr, p.mat = p.mat, hc = hc)
 }
 
 # Build the glyph layer(s) for a given method. Returns a list of ggplot
@@ -798,11 +856,24 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
   diag(cormat) <- NA
   cormat
 }
-# hc.order correlation matrix
+# hc.order correlation matrix. Returns the whole hclust object (its $order gives
+# the reordering; the tree itself is needed to draw cluster rectangles, hc.rect).
 .hc_cormat_order <- function(cormat, hc.method = "complete") {
   dd <- stats::as.dist((1 - cormat) / 2)
-  hc <- stats::hclust(dd, method = hc.method)
-  hc$order
+  stats::hclust(dd, method = hc.method)
+}
+
+# Contiguous block bounds (in dendrogram-order axis positions 1..n) for the k
+# clusters of an hclust tree. cutree() labels each variable with its cluster;
+# reindexing by hc$order puts them in the same order as the plotted axes, where
+# each cluster is guaranteed to be a contiguous run (a property of the dendrogram
+# leaf order), so rle() gives exactly k blocks. Returns lo/hi position of each.
+.hc_rect_bounds <- function(hc, k) {
+  cl <- stats::cutree(hc, k = k)[hc$order]
+  runs <- rle(cl)
+  hi <- cumsum(runs$lengths)
+  lo <- hi - runs$lengths + 1L
+  list(lo = lo, hi = hi)
 }
 
 .no_panel <- function() {

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -42,7 +42,8 @@ ggcorrplot(
   circle.scale = 1,
   coord.fixed = TRUE,
   lower.method = NULL,
-  upper.method = NULL
+  upper.method = NULL,
+  hc.rect = NULL
 )
 
 cor_pmat(x, ..., use = c("pairwise.complete.obs", "everything"))
@@ -99,6 +100,14 @@ length-3 vector for the low, mid and high correlation values (mapped with
 using hclust function.}
 
 \item{hc.method}{the agglomeration method to be used in hclust (see ?hclust).}
+
+\item{hc.rect}{integer or \code{NULL} (default). If an integer \code{k}, draws
+\code{k} rectangles (fixed style: grey outline, no fill) around the clusters
+obtained by cutting the hierarchical tree, marking the cluster blocks on the
+diagonal. Requires \code{hc.order = TRUE} and \code{type = "full"} (the boxes
+span whole diagonal blocks). \code{NULL} (default) draws no rectangles. For a
+custom box style, add your own \code{annotate("rect", ...)} to the returned
+plot.}
 
 \item{lab}{logical value. If TRUE, add correlation coefficient on the plot.}
 
@@ -237,6 +246,8 @@ ggcorrplot(corr,
 # --------------------------------
 # using hierarchical clustering
 ggcorrplot(corr, hc.order = TRUE, outline.color = "white")
+# draw rectangles around the clusters
+ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, outline.color = "white")
 
 # Types of correlogram layout
 # --------------------------------

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-hc-rect.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-hc-rect.svg
@@ -1,0 +1,227 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw'>
+    <rect x='50.82' y='0.00' width='618.36' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw)'>
+<rect x='50.82' y='0.00' width='618.36' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg=='>
+    <rect x='86.59' y='22.78' width='517.27' height='517.27' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg==)'>
+<polyline points='86.59,512.35 603.86,512.35 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,466.16 603.86,466.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,419.98 603.86,419.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,373.79 603.86,373.79 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,327.61 603.86,327.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,281.42 603.86,281.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,235.24 603.86,235.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,189.05 603.86,189.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,142.86 603.86,142.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,96.68 603.86,96.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,50.49 603.86,50.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='114.30,540.06 114.30,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='160.48,540.06 160.48,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='206.67,540.06 206.67,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='252.85,540.06 252.85,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='299.04,540.06 299.04,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='345.22,540.06 345.22,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='391.41,540.06 391.41,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.59,540.06 437.59,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='483.78,540.06 483.78,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='529.96,540.06 529.96,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='576.15,540.06 576.15,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<rect x='91.21' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='137.39' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='183.58' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='229.76' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='275.95' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='322.13' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='368.32' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='414.50' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='460.69' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC6B2;' />
+<rect x='506.87' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='553.06' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='91.21' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='137.39' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='183.58' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='229.76' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='275.95' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='322.13' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='368.32' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='414.50' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='460.69' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='506.87' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='553.06' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='91.21' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='137.39' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='183.58' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='229.76' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='275.95' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='322.13' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='368.32' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='414.50' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='460.69' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='506.87' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='553.06' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='91.21' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='137.39' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='183.58' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='229.76' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='275.95' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='322.13' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='368.32' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='414.50' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='460.69' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='506.87' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='553.06' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='91.21' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='137.39' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='183.58' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='229.76' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='275.95' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='322.13' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='368.32' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='414.50' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='460.69' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='506.87' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='553.06' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='91.21' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='137.39' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='183.58' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='229.76' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='275.95' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='322.13' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='368.32' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='414.50' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='460.69' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='506.87' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='553.06' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='91.21' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='137.39' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='183.58' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='229.76' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='275.95' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='368.32' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='414.50' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='460.69' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='506.87' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='553.06' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='91.21' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='137.39' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='183.58' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='229.76' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='275.95' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='322.13' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='368.32' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='414.50' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='460.69' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='506.87' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF8969;' />
+<rect x='553.06' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='91.21' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC6B2;' />
+<rect x='137.39' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='183.58' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='229.76' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='275.95' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='322.13' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='368.32' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='414.50' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='460.69' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='506.87' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='553.06' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='91.21' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='137.39' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='183.58' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='229.76' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='275.95' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='322.13' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='368.32' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='414.50' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF8969;' />
+<rect x='460.69' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='506.87' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='553.06' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='91.21' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='137.39' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='183.58' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='229.76' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='275.95' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='368.32' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='414.50' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='460.69' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='506.87' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='553.06' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='91.21' y='304.51' width='230.93' height='230.93' style='stroke-width: 1.07; stroke: #4D4D4D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='212.14' width='92.37' height='92.37' style='stroke-width: 1.07; stroke: #4D4D4D; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='27.40' width='184.74' height='184.74' style='stroke-width: 1.07; stroke: #4D4D4D; stroke-linecap: butt; stroke-linejoin: miter;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='81.66' y='516.47' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text x='81.66' y='470.29' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text x='81.66' y='424.10' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text x='81.66' y='377.92' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='81.66' y='331.73' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='81.66' y='285.55' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text x='81.66' y='239.36' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text x='81.66' y='193.18' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text x='81.66' y='146.99' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text x='81.66' y='100.81' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='81.66' y='54.62' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text transform='translate(120.14,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text transform='translate(166.32,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(212.51,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text transform='translate(258.69,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text transform='translate(304.88,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(351.06,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text transform='translate(397.25,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text transform='translate(443.43,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text transform='translate(489.62,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text transform='translate(535.80,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text transform='translate(581.99,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
+<image width='17.28' height='86.40' x='620.30' y='245.89' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAsUlEQVQ4jbWPwQ7DIAxDH2aTpv3/t05aW2CngWChTSvtYjmxYwMFingK8YiIewMhYkTchIgGyGLhOzaI/S60cTAHRNCvOlwE68Jix5b5bZ8Srlm8ve2DB+O0cn/se91tjo4zz/ifxfs+AioFVHKFMmEcW/ZTcBZ58y6e5WtRjrN8Ws3GS62ivBtlqr0wDciDz2nJRtEgmKOxS3WXhl1lFmypY2tlywZaEui9gV4rAKV8ANuwLHQSilYnAAAAAElFTkSuQmCC'/>
+<polyline points='634.12,332.14 637.58,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,310.61 637.58,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,289.09 637.58,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,267.56 637.58,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,246.03 637.58,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,332.14 620.30,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,310.61 620.30,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,289.09 620.30,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,267.56 620.30,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,246.03 620.30,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='643.06' y='335.17' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='643.06' y='313.64' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='643.06' y='292.11' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='643.06' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='643.06' y='249.06' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='86.59' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='148.21px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - hc.rect</text>
+</g>
+</svg>

--- a/tests/testthat/test-hc-rect.R
+++ b/tests/testthat/test-hc-rect.R
@@ -1,0 +1,101 @@
+# Cluster rectangles (P0.3): hc.rect = k draws k boxes around the hierarchical
+# clusters, on top of the glyph layer. Requires hc.order = TRUE.
+
+corr <- round(cor(mtcars), 1)
+n <- ncol(mtcars)
+
+geoms <- function(p) unname(vapply(p$layers, function(l) class(l$geom)[1], character(1)))
+rect_data <- function(p) {
+  b <- ggplot2::ggplot_build(p)
+  i <- which(geoms(p) == "GeomRect")
+  b$data[[i]]
+}
+
+test_that("hc.rect = NULL (default) adds no rectangle layer", {
+  expect_false("GeomRect" %in% geoms(ggcorrplot(corr, hc.order = TRUE)))
+  expect_false("GeomRect" %in% geoms(ggcorrplot(corr)))
+})
+
+test_that("hc.rect = k draws exactly k rectangles on top of the tiles", {
+  p <- ggcorrplot(corr, hc.order = TRUE, hc.rect = 3)
+  expect_equal(geoms(p), c("GeomTile", "GeomRect"))
+  expect_equal(nrow(rect_data(p)), 3)
+})
+
+test_that("the rectangles are square diagonal blocks at half-integer bounds", {
+  rd <- rect_data(ggcorrplot(corr, hc.order = TRUE, hc.rect = 4))
+  # square: x-span equals y-span for every block
+  expect_equal(rd$xmin, rd$ymin)
+  expect_equal(rd$xmax, rd$ymax)
+  # half-integer cell boundaries within the n x n grid
+  expect_true(all((rd$xmin %% 1) == 0.5))
+  expect_true(all((rd$xmax %% 1) == 0.5))
+  expect_gte(min(rd$xmin), 0.5)
+  expect_lte(max(rd$xmax), n + 0.5)
+})
+
+test_that("the k blocks are contiguous and partition all n variables", {
+  # this is the correctness property: cutree clusters are contiguous in
+  # dendrogram order, so the blocks tile 1..n with no gap or overlap
+  for (k in c(1, 2, 3, 5, n)) {
+    rd <- rect_data(ggcorrplot(corr, hc.order = TRUE, hc.rect = k))
+    lo <- sort(rd$xmin + 0.5)
+    hi <- sort(rd$xmax - 0.5)
+    expect_equal(nrow(rd), k)
+    expect_equal(min(lo), 1) # first block starts at position 1
+    expect_equal(max(hi), n) # last block ends at position n
+    # each block's end is the next block's start - 1 (no gap, no overlap)
+    expect_equal(hi[-k], lo[-1] - 1)
+  }
+})
+
+test_that("hc.rect requires hc.order = TRUE", {
+  expect_error(ggcorrplot(corr, hc.rect = 3), "hc.order")
+})
+
+test_that("hc.rect requires type = 'full' (no boxes over a blanked triangle)", {
+  expect_error(ggcorrplot(corr, hc.order = TRUE, type = "lower", hc.rect = 3), "full")
+  expect_error(ggcorrplot(corr, hc.order = TRUE, type = "upper", hc.rect = 3), "full")
+})
+
+test_that("hc.rect refuses to draw a wrong box when the axis is reordered by name", {
+  # numeric-looking dimnames make melt() type-convert the axis to a continuous
+  # scale sorted by value, silently discarding hc.order -- the box would frame
+  # the wrong cells, so it must error rather than mislead (#37 class)
+  mn <- corr
+  dimnames(mn) <- list(as.character(seq_len(n)), as.character(seq_len(n)))
+  expect_error(ggcorrplot(mn, hc.order = TRUE, hc.rect = 3), "numeric-looking")
+  expect_error(ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, as.is = TRUE), "as.is")
+  # a mixed layout coerces the axis to a factor in cluster order, so there the
+  # boxes DO line up even with numeric names
+  expect_s3_class(
+    ggplot2::ggplotGrob(ggcorrplot(mn,
+      hc.order = TRUE, hc.rect = 3, lower.method = "number", upper.method = "circle"
+    )),
+    "gtable"
+  )
+})
+
+test_that("hc.rect validates k", {
+  expect_error(ggcorrplot(corr, hc.order = TRUE, hc.rect = 0), "between 1")
+  expect_error(ggcorrplot(corr, hc.order = TRUE, hc.rect = n + 1), "between 1")
+  expect_error(ggcorrplot(corr, hc.order = TRUE, hc.rect = 2.5), "integer")
+  expect_error(ggcorrplot(corr, hc.order = TRUE, hc.rect = c(2, 3)), "single")
+})
+
+test_that("hc.rect composes with a mixed layout and renders", {
+  expect_s3_class(
+    ggplot2::ggplotGrob(ggcorrplot(corr,
+      hc.order = TRUE, hc.rect = 3,
+      lower.method = "number", upper.method = "circle"
+    )),
+    "gtable"
+  )
+})
+
+test_that("adding hc.rect does not break partial matching of hc.order/hc.method", {
+  # hc.rect shares the already-ambiguous 'hc' prefix; the unique 'hc.o'/'hc.m'
+  # abbreviations must still resolve
+  expect_true("GeomRect" %in% geoms(ggcorrplot(corr, hc.o = TRUE, hc.rect = 2)))
+  expect_silent(ggcorrplot(corr, hc.order = TRUE, hc.m = "average"))
+})

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -14,13 +14,25 @@ test_that(".build_corr_df returns the melted corr frame and a NULL p.mat when no
     hc.order = FALSE, hc.method = "complete", digits = 2,
     sig.level = 0.05, insig = "pch", as.is = FALSE
   )
-  expect_named(b, c("corr", "p.mat"))
+  expect_named(b, c("corr", "p.mat", "hc"))
   expect_s3_class(b$corr, "data.frame")
   expect_null(b$p.mat)
+  expect_null(b$hc) # no clustering requested
   expect_true(all(c("Var1", "Var2", "value", "pvalue", "signif", "abs_corr") %in% names(b$corr)))
   expect_equal(nrow(b$corr), n * n)
   # with no p.mat, significance columns are all NA
   expect_true(all(is.na(b$corr$pvalue)))
+})
+
+test_that(".build_corr_df returns the hclust object when hc.order = TRUE", {
+  b <- .build_corr_df(
+    corr = corr, p.mat = NULL, type = "full", show.diag = TRUE,
+    hc.order = TRUE, hc.method = "complete", digits = 2,
+    sig.level = 0.05, insig = "pch", as.is = FALSE
+  )
+  expect_s3_class(b$hc, "hclust")
+  # its $order reproduces the reordering applied to the melted data
+  expect_identical(levels(b$corr$Var1), colnames(corr)[b$hc$order])
 })
 
 test_that(".build_corr_df joins p-values and returns the insignificant-cells frame", {

--- a/tests/testthat/test-vdiffr.R
+++ b/tests/testthat/test-vdiffr.R
@@ -37,5 +37,11 @@ if (getRversion() >= "4.1") {
         show.legend = FALSE
       )
     )
+
+    set.seed(123)
+    vdiffr::expect_doppelganger(
+      title = "ggcorrplot works - hc.rect",
+      fig = ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, outline.color = "white")
+    )
   })
 }


### PR DESCRIPTION
Adds `hc.rect` — rectangles around the clusters of a hierarchically-ordered correlogram.

```r
ggcorrplot(round(cor(mtcars), 1), hc.order = TRUE, hc.rect = 3)
```

An integer `k` cuts the hierarchical tree into `k` clusters and frames each contiguous block on the diagonal; `NULL` (default) draws nothing. It requires `hc.order = TRUE` (the variables must be in dendrogram order for the clusters to be contiguous blocks).

Non-regression details:
- `.hc_cormat_order()` now returns the whole `hclust` object; its `$order` gives the same reordering as before, so existing `hc.order` output is byte-identical (verified over the full argument-combination fingerprint, including the unrounded-matrix cluster fixtures). `.build_corr_df()` threads the tree back so the blocks can be computed with `cutree()`.
- `hc.rect` is appended at the **end** of the signature (positional binding unchanged) and its `hc.` prefix collides with no unique existing abbreviation (`hc.o`→`hc.order`, `hc.m`→`hc.method` still resolve).

Adds `test-hc-rect.R` (rectangle count, square diagonal blocks, contiguous partition of all variables, validation, partial-matching) and an `hc.rect` vdiffr snapshot; existing tests and snapshots are unchanged.
