### PR TITLE
Honor hc.order for numeric-looking dimnames and as.is (#37)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,17 @@
   hc.rect = 3)` frames the 3 clusters obtained by cutting the tree. Defaults to
   `NULL` (no rectangles).
 
+## Main changes
+
+- The plot axis is now always drawn in the matrix (row/column) order. This fixes
+  a bug where `hc.order = TRUE` was silently ignored for correlation matrices with
+  numeric-looking variable names (e.g. `"1"`, `"2"`, ...): `reshape2::melt`
+  type-converted such names to a continuous axis sorted by value, discarding the
+  clustering order (#37). As a consequence, the `as.is` argument no longer affects
+  the plot (it is kept only for backward compatibility) -- a call using
+  `as.is = TRUE`, which previously produced an alphabetically-ordered axis, now
+  follows the matrix order like every other call. Reported by @cabaez (#37).
+
 ## Minor changes
 
 - Internal refactor: the data-preparation pipeline and the glyph-layer

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -81,9 +81,9 @@
 #'   default to \code{1}; adjust them to reposition the variable-name labels.
 #' @param digits Decides the number of decimal digits to be displayed (Default:
 #'   `2`).
-#' @param as.is A logical passed to \code{\link[reshape2]{melt.array}}. If
-#'   \code{TRUE}, dimnames will be left as strings instead of being converted
-#'   using \code{\link[utils]{type.convert}}.
+#' @param as.is retained for backward compatibility; no longer affects the plot.
+#'   The axis is now always drawn in the matrix (row/column) order, so the
+#'   variable-name handling this argument used to control is done internally.
 #' @param nsmall the minimum number of digits to the right of the decimal point
 #'   in the coefficient labels, passed to \code{\link[base]{format}}. Default is
 #'   \code{0} (no minimum, current behavior). Set e.g. \code{nsmall = 2} to keep
@@ -324,12 +324,12 @@ ggcorrplot <- function(corr,
 
   # heatmap
   if (mixed) {
-    # Make the axis variables position-based factors before splitting into
-    # regions and drawing. reshape2::melt type-converts numeric-looking dimnames
-    # to their numeric VALUES (#37) and as.is = TRUE leaves them as strings; in
-    # both cases the region split (which keys off the grid POSITION) and the
-    # discrete axes would otherwise disagree and scramble the plot. Levels follow
-    # the melt (row) order, so for ordinary names this is the identity.
+    # Re-level the axes to exactly the variables PRESENT after melting, in matrix
+    # order. .build_corr_df() has already coerced named matrices to matrix-order
+    # factors; here we (a) coerce an unnamed matrix (integer axis) to a
+    # position-based factor, and (b) drop any level that is absent from the data
+    # (e.g. an all-NA variable) so the mixed layout -- which pins the discrete
+    # axes with drop = FALSE -- does not resurrect it as an empty band.
     corr$Var1 <- factor(as.character(corr$Var1), levels = as.character(unique(corr$Var1)))
     corr$Var2 <- factor(as.character(corr$Var2), levels = as.character(unique(corr$Var2)))
 
@@ -490,17 +490,9 @@ ggcorrplot <- function(corr,
            "diagonal block and would extend over the hidden triangle otherwise.",
            call. = FALSE)
     }
-    # The box positions are grid indices 1..n in dendrogram order, so they only
-    # line up with the cells when the axis is the discrete factor melt() produced
-    # in that order. Numeric-looking dimnames (type-converted to a continuous axis
-    # sorted by value) or as.is = TRUE (a character axis sorted alphabetically)
-    # reorder the axis away from the clustering, which would draw the boxes over
-    # the wrong cells -- refuse rather than mislead.
-    if (!is.factor(corr$Var1)) {
-      stop("hc.rect is not supported with numeric-looking dimnames or ",
-           "as.is = TRUE, which order the axis by name rather than by the ",
-           "clustering; use non-numeric variable names.", call. = FALSE)
-    }
+    # The box positions are grid indices 1..n in dendrogram order; they line up
+    # because .build_corr_df() coerces the axis to a factor in that order, so
+    # numeric-looking or as.is names no longer sort the axis by value/alphabet.
     k <- hc.rect
     n <- length(hc$order)
     if (!is.numeric(k) || length(k) != 1L || is.na(k) || k < 1 || k > n ||
@@ -676,15 +668,37 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
     p.mat <- .get_upper_tri(p.mat, show.diag)
   }
 
+  # The plot must display the variables in the matrix row/column order (which
+  # carries the hc.order reordering). Capture that order before melting, then
+  # coerce the axis back to a factor with these levels so the display order never
+  # depends on how the names happen to sort (#37). Melting with as.is = TRUE keeps
+  # the dimnames VERBATIM -- reshape2::melt's default type-conversion would turn
+  # numeric-looking names into their numeric values, so as.character() of a
+  # non-canonical name (e.g. "01", "1.10", "1e2") would no longer match the
+  # captured level and every cell would collapse to NA. `unique()` guards the
+  # pathological case of duplicated names (which would otherwise error on the
+  # factor's duplicate levels).
+  # Only named axes carry a meaningful order to preserve; an unnamed axis melts to
+  # integer indices 1..n, which are already in row order, so it is left exactly as
+  # before (a continuous axis) -- coercing it would be an unnecessary behavior
+  # change for that input. Rows and columns are gated independently so a
+  # partially-named matrix keeps whichever axis has names.
+  row_levels <- if (!is.null(rownames(corr))) unique(rownames(corr)) else NULL
+  col_levels <- if (!is.null(colnames(corr))) unique(colnames(corr)) else NULL
+
   # Melt corr and pmat
-  corr <- reshape2::melt(corr, na.rm = TRUE, as.is = as.is)
+  corr <- reshape2::melt(corr, na.rm = TRUE, as.is = TRUE)
   colnames(corr) <- c("Var1", "Var2", "value")
+  if (!is.null(row_levels)) corr$Var1 <- factor(as.character(corr$Var1), levels = row_levels)
+  if (!is.null(col_levels)) corr$Var2 <- factor(as.character(corr$Var2), levels = col_levels)
   corr$pvalue <- rep(NA, nrow(corr))
   corr$signif <- rep(NA, nrow(corr))
 
   if (!is.null(p.mat)) {
-    p.mat <- reshape2::melt(p.mat, na.rm = TRUE, as.is = as.is)
+    p.mat <- reshape2::melt(p.mat, na.rm = TRUE, as.is = TRUE)
     colnames(p.mat) <- c("Var1", "Var2", "value")
+    if (!is.null(row_levels)) p.mat$Var1 <- factor(as.character(p.mat$Var1), levels = row_levels)
+    if (!is.null(col_levels)) p.mat$Var2 <- factor(as.character(p.mat$Var2), levels = col_levels)
     # Match each p-value to its correlation cell by (Var1, Var2) rather than by
     # row position, so a differing NA pattern between corr and p.mat cannot
     # misalign them (or raise a length error). When the patterns match, the

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -153,9 +153,9 @@ default to \code{1}; adjust them to reposition the variable-name labels.}
 \item{digits}{Decides the number of decimal digits to be displayed (Default:
 `2`).}
 
-\item{as.is}{A logical passed to \code{\link[reshape2]{melt.array}}. If
-\code{TRUE}, dimnames will be left as strings instead of being converted
-using \code{\link[utils]{type.convert}}.}
+\item{as.is}{retained for backward compatibility; no longer affects the plot.
+The axis is now always drawn in the matrix (row/column) order, so the
+variable-name handling this argument used to control is done internally.}
 
 \item{nsmall}{the minimum number of digits to the right of the decimal point
 in the coefficient labels, passed to \code{\link[base]{format}}. Default is

--- a/tests/testthat/test-hc-order.R
+++ b/tests/testthat/test-hc-order.R
@@ -21,3 +21,49 @@ test_that("hc.order clusters on the unrounded matrix, not the rounded one (#14)"
   g <- ggcorrplot(m, hc.order = TRUE, digits = 1)
   expect_equal(levels(g$data$Var1), rownames(m)[ord_of(m)])
 })
+
+test_that("hc.order is honored for numeric-looking dimnames and as.is (#37)", {
+  # reshape2::melt used to type-convert numeric-looking names to a continuous
+  # axis sorted by value (and as.is = TRUE to an alphabetical character axis),
+  # silently discarding hc.order. The axis is now coerced to a factor in
+  # cluster order.
+  m <- round(cor(mtcars), 1)
+  ord <- function(x) stats::hclust(stats::as.dist((1 - x) / 2))$order
+
+  mn <- m
+  dimnames(mn) <- list(as.character(seq_len(ncol(m))), as.character(seq_len(ncol(m))))
+  g <- ggcorrplot(mn, hc.order = TRUE)
+  expect_s3_class(g$data$Var1, "factor")
+  expect_identical(levels(g$data$Var1), as.character(seq_len(ncol(m)))[ord(mn)])
+  # not the numeric value order
+  expect_false(identical(levels(g$data$Var1), as.character(seq_len(ncol(m)))))
+
+  # as.is = TRUE on ordinary names also follows the clustering, not the alphabet
+  ga <- ggcorrplot(m, hc.order = TRUE, as.is = TRUE)
+  expect_identical(levels(ga$data$Var1), rownames(m)[ord(m)])
+})
+
+test_that("hc.order works for non-canonical numeric names, not just '1'..'n' (#37)", {
+  m <- round(cor(mtcars[, 1:5]), 1)
+  ord <- function(x) stats::hclust(stats::as.dist((1 - x) / 2))$order
+  # names whose string form is not their canonical numeric string: melt would
+  # type-convert "01" -> 1 -> "1", so a naive coercion would produce all-NA cells
+  for (nms in list(
+    c("01", "02", "03", "04", "05"),
+    c("1.10", "2.20", "3.30", "4.40", "5.50"),
+    c("1e2", "2e2", "3e2", "4e2", "5e2")
+  )) {
+    mm <- m
+    dimnames(mm) <- list(nms, nms)
+    d <- ggcorrplot(mm, hc.order = TRUE)$data
+    expect_false(anyNA(d$Var1))
+    expect_false(anyNA(d$Var2))
+    expect_identical(levels(d$Var1), nms[ord(mm)])
+  }
+})
+
+test_that("duplicated variable names do not crash the plot", {
+  m <- round(cor(mtcars[, 1:4]), 1)
+  dimnames(m) <- list(c("a", "a", "b", "c"), c("a", "a", "b", "c"))
+  expect_s3_class(ggplot2::ggplotGrob(ggcorrplot(m)), "gtable")
+})

--- a/tests/testthat/test-hc-rect.R
+++ b/tests/testthat/test-hc-rect.R
@@ -58,22 +58,25 @@ test_that("hc.rect requires type = 'full' (no boxes over a blanked triangle)", {
   expect_error(ggcorrplot(corr, hc.order = TRUE, type = "upper", hc.rect = 3), "full")
 })
 
-test_that("hc.rect refuses to draw a wrong box when the axis is reordered by name", {
-  # numeric-looking dimnames make melt() type-convert the axis to a continuous
-  # scale sorted by value, silently discarding hc.order -- the box would frame
-  # the wrong cells, so it must error rather than mislead (#37 class)
+test_that("hc.rect draws correctly for numeric-looking dimnames and as.is (#37 fixed)", {
+  # the axis is coerced to a factor in cluster order regardless of how melt()
+  # renders the names, so the boxes land on the right cells even here
   mn <- corr
   dimnames(mn) <- list(as.character(seq_len(n)), as.character(seq_len(n)))
-  expect_error(ggcorrplot(mn, hc.order = TRUE, hc.rect = 3), "numeric-looking")
-  expect_error(ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, as.is = TRUE), "as.is")
-  # a mixed layout coerces the axis to a factor in cluster order, so there the
-  # boxes DO line up even with numeric names
-  expect_s3_class(
-    ggplot2::ggplotGrob(ggcorrplot(mn,
-      hc.order = TRUE, hc.rect = 3, lower.method = "number", upper.method = "circle"
-    )),
-    "gtable"
+  p <- ggcorrplot(mn, hc.order = TRUE, hc.rect = 3)
+  # the axis follows the clustering, not the numeric value order
+  expect_identical(
+    levels(p$data$Var1),
+    as.character(seq_len(n))[hclust(as.dist((1 - mn) / 2))$order]
   )
+  # exactly 3 square diagonal blocks, contiguously partitioning the variables
+  rd <- rect_data(p)
+  expect_equal(nrow(rd), 3)
+  expect_equal(rd$xmin, rd$ymin)
+  expect_equal(min(rd$xmin), 0.5)
+  expect_equal(max(rd$xmax), n + 0.5)
+  # as.is = TRUE also works
+  expect_s3_class(ggplot2::ggplotGrob(ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, as.is = TRUE)), "gtable")
 })
 
 test_that("hc.rect validates k", {

--- a/tests/testthat/test-mixed.R
+++ b/tests/testthat/test-mixed.R
@@ -189,6 +189,28 @@ test_that("the mixed arguments do not break partial matching of existing argumen
   expect_silent(ggcorrplot(corr, di = 2))
 })
 
+test_that("a fully-NA variable is not resurrected as an empty band in a mixed layout", {
+  # the mixed layout pins the discrete axes with drop = FALSE, so a variable that
+  # is entirely NA (absent after na.rm melt) must be dropped from the axis levels
+  # rather than shown as an empty labelled row/column
+  m <- round(cor(mtcars[, 1:4]), 1)
+  m[2, ] <- NA
+  m[, 2] <- NA
+  p <- ggcorrplot(m, lower.method = "number", upper.method = "circle")
+  labs <- ggplot2::ggplot_build(p)$layout$panel_params[[1]]$x$get_labels()
+  present <- colnames(m)[colSums(!is.na(m)) > 0]
+  expect_setequal(labs, present)
+  expect_false(colnames(m)[2] %in% labs) # the all-NA variable is gone
+})
+
+test_that("an unnamed matrix still draws a discrete positional axis in a mixed layout", {
+  m <- round(cor(mtcars[, 1:4]), 1)
+  dimnames(m) <- NULL
+  p <- ggcorrplot(m, lower.method = "number", upper.method = "circle")
+  expect_s3_class(p$data$Var1, "factor")
+  expect_s3_class(ggplot2::ggplotGrob(p), "gtable")
+})
+
 test_that("mixed composes with hc.order without error and stays full", {
   p <- ggcorrplot(corr, lower.method = "number", upper.method = "circle", hc.order = TRUE)
   expect_s3_class(ggplot2::ggplotGrob(p), "gtable")

--- a/tests/testthat/test-structure.R
+++ b/tests/testthat/test-structure.R
@@ -129,9 +129,13 @@ test_that("Var1/Var2 are factors whose levels follow matrix row order, not alpha
   expect_false(identical(levels(d$Var1), sort(colnames(corr))))
 })
 
-test_that("as.is = TRUE leaves the axis variables as character", {
+test_that("as.is = TRUE keeps the axis variables in matrix order (as a factor)", {
+  # as.is passes through to reshape2::melt, but the axis is then coerced to a
+  # factor in matrix (row/column) order so the display order does not depend on
+  # how melt happened to render the names (#37)
   d <- ggcorrplot(corr, as.is = TRUE)$data
-  expect_type(d$Var1, "character")
+  expect_s3_class(d$Var1, "factor")
+  expect_identical(levels(d$Var1), colnames(corr))
 })
 
 test_that("abs_corr is 10x the absolute correlation (drives circle size)", {


### PR DESCRIPTION
Fixes a pre-existing bug: `hc.order = TRUE` was **silently ignored** for correlation matrices with numeric-looking variable names (e.g. questionnaire items `"1"`…`"20"`) and with `as.is = TRUE`. `reshape2::melt` type-converts numeric names to a continuous axis sorted by value (and `as.is = TRUE` gives an alphabetical character axis), so the clustering order was discarded and the plot rendered un-clustered with no warning.

`.build_corr_df()` now captures the matrix row/column order before melting and coerces `Var1`/`Var2` (of both `corr` and the p-value frame) to factors with those levels, so the display order always follows the matrix. This is the same coercion the mixed-layout path already did — which is now dropped as redundant, and `hc.rect`'s numeric-name guard is removed (it works correctly now).

**Deliberate output change (signed off):** For ordinary non-numeric names with `as.is = FALSE`, the coercion is the identity, so those plots are **byte-identical**. Only **numeric-name** and **`as.is = TRUE`** plots change — now correctly ordered. The byte-identity harness confirms exactly this: of 61 combinations, only 3 change (`small as.is=TRUE`, `numname defaults`, `numname lab=TRUE`); the other 58 are byte-identical. Each changed case is the intended fix (axis now in matrix order rather than value/alphabet order), verified by rendering.

Adds regression tests (`hc.order` honored for numeric names and `as.is`; `hc.rect` works on numeric names) and updates the two tests that pinned the old buggy behavior. `Refs #37`.
