### PR TITLE
Add insig = 'stars' for a standalone significance map

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,5 +34,5 @@ Suggests:
     vdiffr (>= 1.0.0)
 Encoding: UTF-8
 Language: en-US
-RoxygenNote: 7.1.0
 Config/testthat/edition: 3
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## New features
 
+- New value `insig = "stars"` to mark the significant cells with significance
+  stars (`***`/`**`/`*` for p < 0.001/0.01/0.05) instead of crossing out the
+  insignificant ones. Works without `lab`, so `ggcorrplot(corr, p.mat = p.mat,
+  insig = "stars")` is a standalone significance map. The default `insig = "pch"`
+  is unchanged.
+
 - New arguments `lower.method` and `upper.method` for a mixed layout: a different
   glyph per triangle, e.g. the coefficients as numbers in the lower triangle,
   circles in the upper, and the variable names on the diagonal

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -70,9 +70,11 @@
 #'   (default), "blank" or "stars". "pch" adds a character (see \code{pch}) on the
 #'   glyphs of the insignificant cells; "blank" wipes those glyphs away; "stars"
 #'   instead marks the SIGNIFICANT cells with significance stars
-#'   (\code{***}/\code{**}/\code{*} for p < 0.001/0.01/0.05), drawn in
-#'   \code{pch.col} and sized by \code{lab_size}, independent of \code{lab} -- a
-#'   standalone significance map.
+#'   (\code{***}/\code{**}/\code{*} for p < 0.001/0.01/0.05). With the default
+#'   \code{lab = FALSE} the stars are drawn on their own (in \code{pch.col}, sized
+#'   by \code{lab_size}) as a standalone significance map; with \code{lab = TRUE}
+#'   they are appended to the coefficient labels (e.g. \code{"-0.85***"}, as with
+#'   \code{sig.stars}) so the two do not overprint.
 #' @param pch add character on the glyphs of insignificant correlation
 #'   coefficients (only valid when insig is "pch"). Default value is 4.
 #' @param pch.col,pch.cex the color and the cex (size) of pch (only valid when
@@ -447,7 +449,13 @@ ggcorrplot <- function(corr,
   if (!mixed) {
     label <- .format_coef(corr[, "value"], digits = digits, nsmall = nsmall,
                           leading.zero = leading.zero)
-    if (sig.stars && !is.null(p.mat)) {
+    # Append significance stars to the coefficient labels for sig.stars, and also
+    # for insig = "stars" when labels are shown (lab = TRUE): the stars share the
+    # label's cell center, so routing them into the suffix here -- rather than
+    # adding the standalone geom_text below -- avoids two text layers overprinting
+    # into illegible output. For all other insig values this reduces to the
+    # sig.stars condition exactly as before (byte-identical).
+    if ((sig.stars || insig == "stars") && !is.null(p.mat)) {
       label <- paste0(label, .sig_stars(corr$pvalue))
     }
     if (!is.null(p.mat) & insig == "blank") {
@@ -480,12 +488,10 @@ ggcorrplot <- function(corr,
     }
 
     # standalone significance stars: mark the SIGNIFICANT cells with */**/***
-    # (non-significant cells get nothing), independent of lab. Keyed off the
-    # per-cell p-values, so it works as a significance-only map with lab = FALSE.
-    # Suppress only when the sig.stars label suffix will actually draw the stars
-    # (it needs lab = TRUE); otherwise insig = "stars" with sig.stars = TRUE and
-    # lab = FALSE would render neither and leave a bare heatmap.
-    if (!is.null(p.mat) & insig == "stars" & !(sig.stars & lab)) {
+    # (non-significant cells get nothing) as a significance-only map. Only drawn
+    # when lab = FALSE; with lab = TRUE the stars are appended to the coefficient
+    # labels above (numbers + stars, one text layer) so the two do not overprint.
+    if (!is.null(p.mat) & insig == "stars" & !lab) {
       p <- p + ggplot2::geom_text(
         mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),
         label = .sig_stars(corr$pvalue),

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -240,7 +240,13 @@ ggcorrplot <- function(corr,
                        hc.rect = NULL) {
   type <- match.arg(type)
   method <- match.arg(method)
-  insig <- match.arg(insig)
+  # Resolve on insig[1] (not match.arg(insig)) so a caller passing the old
+  # documented default vector explicitly -- insig = c("pch", "blank") -- still
+  # collapses to its first element instead of erroring: match.arg() only accepts
+  # a multi-value arg when it is identical to the full choices set, and adding
+  # "stars" made c("pch", "blank") non-identical. Scalar/partial matching and the
+  # default are unchanged.
+  insig <- match.arg(insig[1], c("pch", "blank", "stars"))
   if (is.null(show.diag)) {
     if (type == "full") {
       show.diag <- TRUE
@@ -476,7 +482,10 @@ ggcorrplot <- function(corr,
     # standalone significance stars: mark the SIGNIFICANT cells with */**/***
     # (non-significant cells get nothing), independent of lab. Keyed off the
     # per-cell p-values, so it works as a significance-only map with lab = FALSE.
-    if (!is.null(p.mat) & insig == "stars" & !sig.stars) {
+    # Suppress only when the sig.stars label suffix will actually draw the stars
+    # (it needs lab = TRUE); otherwise insig = "stars" with sig.stars = TRUE and
+    # lab = FALSE would render neither and leave a bare heatmap.
+    if (!is.null(p.mat) & insig == "stars" & !(sig.stars & lab)) {
       p <- p + ggplot2::geom_text(
         mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),
         label = .sig_stars(corr$pvalue),

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -66,9 +66,13 @@
 #' @param sig.level significant level, if the p-value in p-mat is bigger than
 #'   sig.level, then the corresponding correlation coefficient is regarded as
 #'   insignificant.
-#' @param insig character, specialized insignificant correlation coefficients,
-#'   "pch" (default), "blank". If "blank", wipe away the corresponding glyphs;
-#'   if "pch", add characters (see pch for details) on corresponding glyphs.
+#' @param insig character, how to convey significance from \code{p.mat}: "pch"
+#'   (default), "blank" or "stars". "pch" adds a character (see \code{pch}) on the
+#'   glyphs of the insignificant cells; "blank" wipes those glyphs away; "stars"
+#'   instead marks the SIGNIFICANT cells with significance stars
+#'   (\code{***}/\code{**}/\code{*} for p < 0.001/0.01/0.05), drawn in
+#'   \code{pch.col} and sized by \code{lab_size}, independent of \code{lab} -- a
+#'   standalone significance map.
 #' @param pch add character on the glyphs of insignificant correlation
 #'   coefficients (only valid when insig is "pch"). Default value is 4.
 #' @param pch.col,pch.cex the color and the cex (size) of pch (only valid when
@@ -215,7 +219,7 @@ ggcorrplot <- function(corr,
                        sig.stars = FALSE,
                        p.mat = NULL,
                        sig.level = 0.05,
-                       insig = c("pch", "blank"),
+                       insig = c("pch", "blank", "stars"),
                        pch = 4,
                        pch.col = "black",
                        pch.cex = 5,
@@ -438,12 +442,7 @@ ggcorrplot <- function(corr,
     label <- .format_coef(corr[, "value"], digits = digits, nsmall = nsmall,
                           leading.zero = leading.zero)
     if (sig.stars && !is.null(p.mat)) {
-      stars <- as.character(cut(corr$pvalue,
-        breaks = c(-Inf, 0.001, 0.01, 0.05, Inf),
-        labels = c("***", "**", "*", "")
-      ))
-      stars[is.na(stars)] <- ""
-      label <- paste0(label, stars)
+      label <- paste0(label, .sig_stars(corr$pvalue))
     }
     if (!is.null(p.mat) & insig == "blank") {
       ns <- corr$pvalue > sig.level
@@ -471,6 +470,18 @@ ggcorrplot <- function(corr,
         shape = pch,
         size = pch.cex,
         color = pch.col
+      )
+    }
+
+    # standalone significance stars: mark the SIGNIFICANT cells with */**/***
+    # (non-significant cells get nothing), independent of lab. Keyed off the
+    # per-cell p-values, so it works as a significance-only map with lab = FALSE.
+    if (!is.null(p.mat) & insig == "stars" & !sig.stars) {
+      p <- p + ggplot2::geom_text(
+        mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]]),
+        label = .sig_stars(corr$pvalue),
+        color = pch.col,
+        size = lab_size
       )
     }
   }
@@ -761,6 +772,18 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
     label <- gsub("\\b0(\\.\\d+)", "\\1", label)
   }
   label
+}
+
+# Significance stars for a vector of p-values: "***" p < 0.001, "**" p < 0.01,
+# "*" p < 0.05, "" otherwise (and "" for NA). Shared by the sig.stars label
+# suffix and the standalone insig = "stars" glyph so both use one definition.
+.sig_stars <- function(pvalue) {
+  stars <- as.character(cut(pvalue,
+    breaks = c(-Inf, 0.001, 0.01, 0.05, Inf),
+    labels = c("***", "**", "*", "")
+  ))
+  stars[is.na(stars)] <- ""
+  stars
 }
 
 # Build the layers for a mixed layout: a per-triangle glyph over the lower

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -132,9 +132,13 @@ pch.col, pch.cex is invalid.}
 sig.level, then the corresponding correlation coefficient is regarded as
 insignificant.}
 
-\item{insig}{character, specialized insignificant correlation coefficients,
-"pch" (default), "blank". If "blank", wipe away the corresponding glyphs;
-if "pch", add characters (see pch for details) on corresponding glyphs.}
+\item{insig}{character, how to convey significance from \code{p.mat}: "pch"
+(default), "blank" or "stars". "pch" adds a character (see \code{pch}) on the
+glyphs of the insignificant cells; "blank" wipes those glyphs away; "stars"
+instead marks the SIGNIFICANT cells with significance stars
+(\code{***}/\code{**}/\code{*} for p < 0.001/0.01/0.05), drawn in \code{pch.col}
+and sized by \code{lab_size}, independent of \code{lab} -- a standalone
+significance map.}
 
 \item{pch}{add character on the glyphs of insignificant correlation
 coefficients (only valid when insig is "pch"). Default value is 4.}

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -25,7 +25,7 @@ ggcorrplot(
   sig.stars = FALSE,
   p.mat = NULL,
   sig.level = 0.05,
-  insig = c("pch", "blank"),
+  insig = c("pch", "blank", "stars"),
   pch = 4,
   pch.col = "black",
   pch.cex = 5,
@@ -53,17 +53,6 @@ cor_pmat(x, ..., use = c("pairwise.complete.obs", "everything"))
 
 \item{method}{character, the visualization method of correlation matrix to be
 used. Allowed values are "square" (default), "circle".}
-
-\item{lower.method, upper.method}{character, an optional per-triangle glyph for
-a mixed layout: one of "square", "circle" or "number" (the coefficient drawn
-as text, colored by its value on the same scale as the fill, so coefficients
-near zero are faint). When either is set, the plot switches to a mixed layout
-where the lower and upper triangles are drawn separately and the variable names
-are drawn on the diagonal; a triangle left \code{NULL} uses \code{method}. Both
-default to \code{NULL} (single-method plot, unchanged). In a mixed layout the
-single-method significance and label overlays (\code{lab}, \code{sig.stars},
-\code{p.mat}, \code{insig}, \code{pch*}) do not apply; show coefficients with a
-"number" triangle instead.}
 
 \item{type}{character, "full" (default), "lower" or "upper" display. A mixed
 layout (see \code{lower.method}/\code{upper.method}) always uses the full
@@ -100,14 +89,6 @@ length-3 vector for the low, mid and high correlation values (mapped with
 using hclust function.}
 
 \item{hc.method}{the agglomeration method to be used in hclust (see ?hclust).}
-
-\item{hc.rect}{integer or \code{NULL} (default). If an integer \code{k}, draws
-\code{k} rectangles (fixed style: grey outline, no fill) around the clusters
-obtained by cutting the hierarchical tree, marking the cluster blocks on the
-diagonal. Requires \code{hc.order = TRUE} and \code{type = "full"} (the boxes
-span whole diagonal blocks). \code{NULL} (default) draws no rectangles. For a
-custom box style, add your own \code{annotate("rect", ...)} to the returned
-plot.}
 
 \item{lab}{logical value. If TRUE, add correlation coefficient on the plot.}
 
@@ -187,6 +168,25 @@ small or too large. Has no effect when \code{method = "square"}.}
 \code{\link[ggplot2]{coord_fixed}} so the cells are square. Set to
 \code{FALSE} to let the cells fill the plotting area (a non 1:1 aspect
 ratio), which can look better with many long variable names.}
+
+\item{lower.method, upper.method}{character, an optional per-triangle glyph for
+a mixed layout: one of "square", "circle" or "number" (the coefficient drawn
+as text, colored by its value on the same scale as the fill, so coefficients
+near zero are faint). When either is set, the plot switches to a mixed layout
+where the lower and upper triangles are drawn separately and the variable
+names are drawn on the diagonal; a triangle left \code{NULL} uses
+\code{method}. Both default to \code{NULL} (single-method plot, unchanged).
+In a mixed layout the single-method significance and label overlays
+(\code{lab}, \code{sig.stars}, \code{p.mat}, \code{insig}, \code{pch*}) do
+not apply; show coefficients with a "number" triangle instead.}
+
+\item{hc.rect}{integer or \code{NULL} (default). If an integer \code{k}, draws
+\code{k} rectangles (fixed style: grey outline, no fill) around the clusters
+obtained by cutting the hierarchical tree, marking the cluster blocks on the
+diagonal. Requires \code{hc.order = TRUE} and \code{type = "full"} (the boxes
+span whole diagonal blocks). \code{NULL} (default) draws no rectangles. For a
+custom box style, add your own \code{annotate("rect", ...)} to the returned
+plot.}
 
 \item{x}{numeric matrix or data frame}
 

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -136,9 +136,11 @@ insignificant.}
 (default), "blank" or "stars". "pch" adds a character (see \code{pch}) on the
 glyphs of the insignificant cells; "blank" wipes those glyphs away; "stars"
 instead marks the SIGNIFICANT cells with significance stars
-(\code{***}/\code{**}/\code{*} for p < 0.001/0.01/0.05), drawn in \code{pch.col}
-and sized by \code{lab_size}, independent of \code{lab} -- a standalone
-significance map.}
+(\code{***}/\code{**}/\code{*} for p < 0.001/0.01/0.05). With the default
+\code{lab = FALSE} the stars are drawn on their own (in \code{pch.col}, sized
+by \code{lab_size}) as a standalone significance map; with \code{lab = TRUE}
+they are appended to the coefficient labels (e.g. \code{"-0.85***"}, as with
+\code{sig.stars}) so the two do not overprint.}
 
 \item{pch}{add character on the glyphs of insignificant correlation
 coefficients (only valid when insig is "pch"). Default value is 4.}

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-insig-stars.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-insig-stars.svg
@@ -1,0 +1,323 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw'>
+    <rect x='50.82' y='0.00' width='618.36' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw)'>
+<rect x='50.82' y='0.00' width='618.36' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg=='>
+    <rect x='86.59' y='22.78' width='517.27' height='517.27' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg==)'>
+<polyline points='86.59,512.35 603.86,512.35 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,466.16 603.86,466.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,419.98 603.86,419.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,373.79 603.86,373.79 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,327.61 603.86,327.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,281.42 603.86,281.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,235.24 603.86,235.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,189.05 603.86,189.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,142.86 603.86,142.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,96.68 603.86,96.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,50.49 603.86,50.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='114.30,540.06 114.30,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='160.48,540.06 160.48,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='206.67,540.06 206.67,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='252.85,540.06 252.85,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='299.04,540.06 299.04,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='345.22,540.06 345.22,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='391.41,540.06 391.41,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.59,540.06 437.59,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='483.78,540.06 483.78,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='529.96,540.06 529.96,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='576.15,540.06 576.15,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<rect x='91.21' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='137.39' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='183.58' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='229.76' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='275.95' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='322.13' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='368.32' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='414.50' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='460.69' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF8969;' />
+<rect x='506.87' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='553.06' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='91.21' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='137.39' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='183.58' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='229.76' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='275.95' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='368.32' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='414.50' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='460.69' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='506.87' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='553.06' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='91.21' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='137.39' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='183.58' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='229.76' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='275.95' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='368.32' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='414.50' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='460.69' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='506.87' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='553.06' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='91.21' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='137.39' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='183.58' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='229.76' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='275.95' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='322.13' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='368.32' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='414.50' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='460.69' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='506.87' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='553.06' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='91.21' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='137.39' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='183.58' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='229.76' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='275.95' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='322.13' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='368.32' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='414.50' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='460.69' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='506.87' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='553.06' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='91.21' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='137.39' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='183.58' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='229.76' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='275.95' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='322.13' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='368.32' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='414.50' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='460.69' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='506.87' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='553.06' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='91.21' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='137.39' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='183.58' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4A2FF;' />
+<rect x='229.76' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='275.95' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='322.13' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='368.32' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='414.50' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='460.69' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='506.87' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='553.06' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='91.21' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='137.39' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='183.58' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='229.76' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='275.95' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='322.13' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='368.32' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='414.50' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='460.69' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='506.87' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='553.06' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='91.21' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF8969;' />
+<rect x='137.39' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='183.58' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='229.76' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='275.95' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='322.13' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='368.32' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='414.50' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='460.69' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='506.87' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='553.06' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='91.21' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='137.39' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #B38BFF;' />
+<rect x='183.58' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='229.76' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='275.95' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='322.13' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='368.32' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #E3D0FF;' />
+<rect x='414.50' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFD9CB;' />
+<rect x='460.69' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='506.87' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<rect x='553.06' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC6B2;' />
+<rect x='91.21' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='137.39' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF9E81;' />
+<rect x='183.58' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='229.76' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='275.95' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #F2E7FF;' />
+<rect x='322.13' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFB299;' />
+<rect x='368.32' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #8A5DFF;' />
+<rect x='414.50' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #A074FF;' />
+<rect x='460.69' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFECE5;' />
+<rect x='506.87' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFC6B2;' />
+<rect x='553.06' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF0000;' />
+<text x='114.30' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='160.48' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='206.67' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='252.85' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='299.04' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='345.22' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='391.41' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='437.59' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='483.78' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='529.96' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='576.15' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='114.30' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='160.48' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='206.67' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='252.85' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='299.04' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='345.22' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='391.41' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='437.59' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='483.78' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='529.96' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='576.15' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='114.30' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='160.48' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='206.67' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='252.85' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='299.04' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='345.22' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='391.41' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='437.59' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='483.78' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='529.96' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='576.15' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='114.30' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='160.48' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='206.67' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='252.85' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='299.04' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='345.22' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='391.41' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='437.59' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='576.15' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='114.30' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='160.48' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='206.67' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='252.85' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='299.04' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='345.22' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='437.59' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='483.78' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='529.96' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='114.30' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='160.48' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='206.67' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='252.85' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='299.04' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='345.22' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='437.59' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='483.78' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='529.96' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='576.15' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='114.30' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='160.48' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='206.67' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='252.85' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='391.41' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='437.59' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='576.15' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='114.30' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='160.48' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='206.67' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='252.85' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='299.04' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='345.22' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='391.41' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='437.59' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='576.15' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='114.30' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='160.48' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='206.67' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='299.04' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='345.22' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='483.78' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='529.96' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='114.30' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='160.48' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='206.67' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='299.04' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='345.22' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='483.78' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='529.96' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='114.30' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='160.48' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='8.86px' lengthAdjust='spacingAndGlyphs'>**</text>
+<text x='206.67' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='252.85' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='345.22' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='4.43px' lengthAdjust='spacingAndGlyphs'>*</text>
+<text x='391.41' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='437.59' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+<text x='576.15' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='13.30px' lengthAdjust='spacingAndGlyphs'>***</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='81.66' y='516.47' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='81.66' y='470.29' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='81.66' y='424.10' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='81.66' y='377.92' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text x='81.66' y='331.73' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='81.66' y='285.55' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text x='81.66' y='239.36' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text x='81.66' y='193.18' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text x='81.66' y='146.99' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text x='81.66' y='100.81' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text x='81.66' y='54.62' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text transform='translate(120.14,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text transform='translate(166.32,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text transform='translate(212.51,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(258.69,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text transform='translate(304.88,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text transform='translate(351.06,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(397.25,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text transform='translate(443.43,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text transform='translate(489.62,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text transform='translate(535.80,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text transform='translate(581.99,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
+<image width='17.28' height='86.40' x='620.30' y='245.89' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAsUlEQVQ4jbWPwQ7DIAxDH2aTpv3/t05aW2CngWChTSvtYjmxYwMFingK8YiIewMhYkTchIgGyGLhOzaI/S60cTAHRNCvOlwE68Jix5b5bZ8Srlm8ve2DB+O0cn/se91tjo4zz/ifxfs+AioFVHKFMmEcW/ZTcBZ58y6e5WtRjrN8Ws3GS62ivBtlqr0wDciDz2nJRtEgmKOxS3WXhl1lFmypY2tlywZaEui9gV4rAKV8ANuwLHQSilYnAAAAAElFTkSuQmCC'/>
+<polyline points='634.12,332.14 637.58,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,310.61 637.58,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,289.09 637.58,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,267.56 637.58,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,246.03 637.58,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,332.14 620.30,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,310.61 620.30,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,289.09 620.30,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,267.56 620.30,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,246.03 620.30,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='643.06' y='335.17' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='643.06' y='313.64' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='643.06' y='292.11' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='643.06' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='643.06' y='249.06' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='86.59' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='168.01px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - insig stars</text>
+</g>
+</svg>

--- a/tests/testthat/test-insig-stars.R
+++ b/tests/testthat/test-insig-stars.R
@@ -87,6 +87,23 @@ test_that("insig = 'stars' with sig.stars = TRUE and lab = FALSE still draws the
   expect_equal(sum(geoms(p2) == "GeomText"), 1)
 })
 
+test_that("insig = 'stars' with lab = TRUE appends stars to the labels, no second layer", {
+  # lab = TRUE puts the coefficient at the cell center; the stars must be appended
+  # to that label (one GeomText: numbers + stars) rather than drawn as a second
+  # geom_text overprinting into illegible output.
+  p <- ggcorrplot(corr, p.mat = p.mat, insig = "stars", lab = TRUE)
+  expect_equal(sum(geoms(p) == "GeomText"), 1L)
+  labs <- ggplot2::ggplot_build(p)$data[[which(geoms(p) == "GeomText")]]$label
+  # the label carries the number and, on significant cells, the appended stars
+  expect_true(any(grepl("[0-9].*\\*", labs)))
+  # it equals the sig.stars = TRUE, lab = TRUE label (both are numbers + stars)
+  q <- ggcorrplot(corr, p.mat = p.mat, sig.stars = TRUE, lab = TRUE)
+  expect_identical(
+    ggplot2::ggplot_build(p)$data[[which(geoms(p) == "GeomText")]]$label,
+    ggplot2::ggplot_build(q)$data[[which(geoms(q) == "GeomText")]]$label
+  )
+})
+
 test_that("sig.stars and insig = 'stars' share one star definition", {
   # sig.stars appends the SAME stars to the coefficient labels
   p <- ggcorrplot(corr, p.mat = p.mat, lab = TRUE, sig.stars = TRUE)

--- a/tests/testthat/test-insig-stars.R
+++ b/tests/testthat/test-insig-stars.R
@@ -1,0 +1,66 @@
+# insig = "stars" (P1.1): a standalone significance map -- the SIGNIFICANT cells
+# are marked with */**/*** stars, independent of lab. The default insig = "pch"
+# is unchanged (covered by test-pmat.R / test-structure.R and the byte-identity
+# harness); here we lock the new value.
+
+corr <- round(cor(mtcars), 1)
+p.mat <- cor_pmat(mtcars)
+n <- ncol(mtcars)
+
+geoms <- function(p) unname(vapply(p$layers, function(l) class(l$geom)[1], character(1)))
+star_layer_labels <- function(p) {
+  i <- which(geoms(p) == "GeomText")
+  ggplot2::ggplot_build(p)$data[[i]]$label
+}
+
+test_that("insig = 'stars' adds a text layer of significance stars over the tiles", {
+  p <- ggcorrplot(corr, p.mat = p.mat, insig = "stars")
+  expect_equal(geoms(p), c("GeomTile", "GeomText"))
+})
+
+test_that("stars mark significant cells and leave non-significant cells blank", {
+  p <- ggcorrplot(corr, p.mat = p.mat, insig = "stars")
+  lbl <- star_layer_labels(p)
+  d <- ggplot2::ggplot_build(p)$data[[1]] # tiles carry the p-values? no -- rebuild from p.mat
+  # every star string is one of the four valid values
+  expect_true(all(lbl %in% c("***", "**", "*", "")))
+  # a cell is starred iff its p-value is significant at the corresponding level
+  pv <- p.mat[cbind(
+    as.character(ggplot2::ggplot_build(p)$plot$data$Var1),
+    as.character(ggplot2::ggplot_build(p)$plot$data$Var2)
+  )]
+  expected <- .sig_stars(unname(pv))
+  expect_identical(lbl, expected)
+  expect_true(any(lbl == "")) # some non-significant cells exist in mtcars
+})
+
+test_that(".sig_stars maps p-values to the documented thresholds", {
+  expect_identical(
+    .sig_stars(c(0.0005, 0.005, 0.03, 0.2, NA)),
+    c("***", "**", "*", "", "")
+  )
+  # boundaries: cut() is right-closed, so a value exactly on a break falls in the
+  # lower (more-significant) bin -- 0.001 -> ***, 0.01 -> **, 0.05 -> *
+  expect_identical(.sig_stars(c(0.001, 0.01, 0.05)), c("***", "**", "*"))
+  # and just above each break drops a level
+  expect_identical(.sig_stars(c(0.0011, 0.011, 0.051)), c("**", "*", ""))
+})
+
+test_that("insig = 'stars' needs no lab and does not draw the pch layer", {
+  p <- ggcorrplot(corr, p.mat = p.mat, insig = "stars") # lab defaults FALSE
+  expect_false("GeomPoint" %in% geoms(p)) # no pch crosses
+  # the coefficient labels are NOT shown (lab = FALSE): only the stars text layer
+  expect_equal(sum(geoms(p) == "GeomText"), 1)
+})
+
+test_that("the default insig ('pch') is unchanged when 'stars' is added to the set", {
+  expect_equal(geoms(ggcorrplot(corr, p.mat = p.mat)), c("GeomTile", "GeomPoint"))
+  expect_error(ggcorrplot(corr, p.mat = p.mat, insig = "nope"))
+})
+
+test_that("sig.stars and insig = 'stars' share one star definition", {
+  # sig.stars appends the SAME stars to the coefficient labels
+  p <- ggcorrplot(corr, p.mat = p.mat, lab = TRUE, sig.stars = TRUE)
+  labs <- ggplot2::ggplot_build(p)$data[[2]]$label
+  expect_true(any(grepl("\\*", labs)))
+})

--- a/tests/testthat/test-insig-stars.R
+++ b/tests/testthat/test-insig-stars.R
@@ -58,6 +58,35 @@ test_that("the default insig ('pch') is unchanged when 'stars' is added to the s
   expect_error(ggcorrplot(corr, p.mat = p.mat, insig = "nope"))
 })
 
+test_that("the old default vector insig = c('pch', 'blank') still resolves to 'pch'", {
+  # adding "stars" to the choice set must not break a caller that passes the
+  # previously-documented default vector explicitly: match.arg() only accepts a
+  # multi-value arg identical to the full choices, so c("pch", "blank") would
+  # error unless we resolve on insig[1]. It must behave exactly like insig = "pch".
+  expect_error(ggcorrplot(corr, p.mat = p.mat, insig = c("pch", "blank")), NA)
+  a <- ggplot2::ggplot_build(ggcorrplot(corr, p.mat = p.mat, insig = c("pch", "blank")))
+  b <- ggplot2::ggplot_build(ggcorrplot(corr, p.mat = p.mat, insig = "pch"))
+  expect_equal(a$data, b$data)
+})
+
+test_that("insig = 'stars' with sig.stars = TRUE and lab = FALSE still draws the stars", {
+  # sig.stars appends stars to the coefficient labels, but those only exist when
+  # lab = TRUE; with lab = FALSE the standalone stars must still render so the
+  # call is not a bare heatmap.
+  p <- ggcorrplot(corr, p.mat = p.mat, insig = "stars", sig.stars = TRUE)
+  expect_true("GeomText" %in% geoms(p))
+  expect_identical(star_layer_labels(p), .sig_stars(unname(
+    p.mat[cbind(
+      as.character(ggplot2::ggplot_build(p)$plot$data$Var1),
+      as.character(ggplot2::ggplot_build(p)$plot$data$Var2)
+    )]
+  )))
+  # and with lab = TRUE the suffix path draws them, so the standalone layer is
+  # suppressed (no double stars): exactly one GeomText, from the labels
+  p2 <- ggcorrplot(corr, p.mat = p.mat, insig = "stars", sig.stars = TRUE, lab = TRUE)
+  expect_equal(sum(geoms(p2) == "GeomText"), 1)
+})
+
 test_that("sig.stars and insig = 'stars' share one star definition", {
   # sig.stars appends the SAME stars to the coefficient labels
   p <- ggcorrplot(corr, p.mat = p.mat, lab = TRUE, sig.stars = TRUE)

--- a/tests/testthat/test-vdiffr.R
+++ b/tests/testthat/test-vdiffr.R
@@ -43,5 +43,11 @@ if (getRversion() >= "4.1") {
       title = "ggcorrplot works - hc.rect",
       fig = ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, outline.color = "white")
     )
+
+    set.seed(123)
+    vdiffr::expect_doppelganger(
+      title = "ggcorrplot works - insig stars",
+      fig = ggcorrplot(corr, p.mat = p.mat, insig = "stars")
+    )
   })
 }


### PR DESCRIPTION
Adds `insig = "stars"` — a standalone significance map.

```r
ggcorrplot(round(cor(mtcars), 1), p.mat = cor_pmat(mtcars), insig = "stars")
```

Instead of crossing out the *insignificant* cells (`insig = "pch"`), `"stars"` marks the *significant* cells with significance stars (`***`/`**`/`*` for p < 0.001/0.01/0.05), drawn as a text layer keyed off the per-cell p-values. It needs no `lab`, so it works as a significance-only overlay.

The star-string builder is factored into an internal `.sig_stars()` helper shared by this glyph and the `sig.stars` label suffix, so both use one definition.

Non-regression: the default `insig = "pch"` is unchanged (byte-identical across the full argument-combination fingerprint). `"stars"` is added to the `insig` choice set; the default resolves to `"pch"` as before. Adds `test-insig-stars.R` and an `insig="stars"` vdiffr snapshot; existing tests and snapshots unchanged.
