### PR TITLE
Fix show.diag = FALSE on a non-square matrix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,15 @@
   output of any existing call. This is groundwork for forthcoming per-triangle
   layout options.
 
+## Bug fixes
+
+- `show.diag = FALSE` on a non-square matrix no longer blanks the wrong cells.
+  The diagonal has no positional meaning for an m x n matrix, yet the removal
+  wiped `min(m, n)` cells along the leading diagonal; it now removes only the
+  genuine self-pairs (a row and column naming the same variable), leaving a
+  matrix with disjoint row and column variables untouched. Square matrices are
+  unaffected (#5, #10).
+
 # ggcorrplot 0.2.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -44,8 +44,9 @@
   The diagonal has no positional meaning for an m x n matrix, yet the removal
   wiped `min(m, n)` cells along the leading diagonal; it now removes only the
   genuine self-pairs (a row and column naming the same variable), leaving a
-  matrix with disjoint row and column variables untouched. Square matrices are
-  unaffected (#5, #10).
+  matrix with disjoint row and column variables untouched. Square matrices, and
+  non-square matrices without dimnames, are unaffected. Follows up the non-square
+  support requested by @mt1022 (#5) and @qalid7 (#10).
 
 # ggcorrplot 0.2.0
 

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -917,6 +917,10 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
     cn <- colnames(cormat)
     if (!is.null(rn) && !is.null(cn)) {
       cormat[outer(rn, cn, `==`)] <- NA
+    } else {
+      # Unnamed matrix: there are no names to identify self-pairs by, so keep the
+      # historical positional removal (unchanged from previous behavior).
+      diag(cormat) <- NA
     }
   }
   cormat

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -905,7 +905,20 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
   if (is.null(cormat)) {
     return(cormat)
   }
-  diag(cormat) <- NA
+  if (nrow(cormat) == ncol(cormat)) {
+    diag(cormat) <- NA
+  } else {
+    # A non-square (m x n) matrix has no positional diagonal: `diag(cormat) <- NA`
+    # would blank min(m, n) cells at (1,1), (2,2), ... regardless of what variables
+    # sit there, wiping the wrong cells. Remove only the genuine self-pairs -- cells
+    # whose row and column name the same variable -- so a matrix whose row and column
+    # variables are disjoint keeps every cell.
+    rn <- rownames(cormat)
+    cn <- colnames(cormat)
+    if (!is.null(rn) && !is.null(cn)) {
+      cormat[outer(rn, cn, `==`)] <- NA
+    }
+  }
   cormat
 }
 # hc.order correlation matrix. Returns the whole hclust object (its $order gives

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-non-square-no-diag.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-non-square-no-diag.svg
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTUwLjU3fDU2OS40M3wwLjAwfDU3Ni4wMA=='>
+    <rect x='150.57' y='0.00' width='418.86' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTUwLjU3fDU2OS40M3wwLjAwfDU3Ni4wMA==)'>
+<rect x='150.57' y='0.00' width='418.86' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMTg0LjMzfDUwNC4xMXwyMi43OHw1NDIuNDI='>
+    <rect x='184.33' y='22.78' width='319.78' height='519.64' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMTg0LjMzfDUwNC4xMXwyMi43OHw1NDIuNDI=)'>
+<polyline points='184.33,482.46 504.11,482.46 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='184.33,382.53 504.11,382.53 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='184.33,282.60 504.11,282.60 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='184.33,182.67 504.11,182.67 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='184.33,82.74 504.11,82.74 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='244.29,542.42 244.29,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='344.22,542.42 344.22,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='444.15,542.42 444.15,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<rect x='194.32' y='432.50' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='294.25' y='432.50' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #7145FF;' />
+<rect x='394.18' y='432.50' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #502BFF;' />
+<rect x='194.32' y='332.57' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='294.25' y='332.57' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='394.18' y='332.57' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='294.25' y='232.64' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='394.18' y='232.64' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='194.32' y='132.71' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF5B3A;' />
+<rect x='394.18' y='132.71' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<rect x='194.32' y='32.78' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF3E22;' />
+<rect x='294.25' y='32.78' width='99.93' height='99.93' style='stroke-width: 0.43; stroke: #BEBEBE; stroke-linecap: butt; stroke-linejoin: miter; fill: #FF7352;' />
+<text x='244.29' y='486.38' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='344.22' y='486.38' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='444.15' y='486.38' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.9</text>
+<text x='244.29' y='386.45' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='344.22' y='386.45' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='444.15' y='386.45' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='344.22' y='286.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='444.15' y='286.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='244.29' y='186.59' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='444.15' y='186.59' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='244.29' y='86.66' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='344.22' y='86.66' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='179.40' y='486.59' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='179.40' y='386.66' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='179.40' y='286.73' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='179.40' y='186.80' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text x='179.40' y='86.87' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(250.13,553.19) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(350.06,553.19) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text transform='translate(449.99,553.19) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text x='520.55' y='240.45' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
+<image width='17.28' height='86.40' x='520.55' y='247.07' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAsUlEQVQ4jbWPwQ7DIAxDH2aTpv3/t05aW2CngWChTSvtYjmxYwMFingK8YiIewMhYkTchIgGyGLhOzaI/S60cTAHRNCvOlwE68Jix5b5bZ8Srlm8ve2DB+O0cn/se91tjo4zz/ifxfs+AioFVHKFMmEcW/ZTcBZ58y6e5WtRjrN8Ws3GS62ivBtlqr0wDciDz2nJRtEgmKOxS3WXhl1lFmypY2tlywZaEui9gV4rAKV8ANuwLHQSilYnAAAAAElFTkSuQmCC'/>
+<polyline points='534.37,333.32 537.83,333.32 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='534.37,311.80 537.83,311.80 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='534.37,290.27 537.83,290.27 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='534.37,268.74 537.83,268.74 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='534.37,247.21 537.83,247.21 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='524.00,333.32 520.55,333.32 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='524.00,311.80 520.55,311.80 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='524.00,290.27 520.55,290.27 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='524.00,268.74 520.55,268.74 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='524.00,247.21 520.55,247.21 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='543.31' y='336.35' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='543.31' y='314.82' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='543.31' y='293.30' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='543.31' y='271.77' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='543.31' y='250.24' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='184.33' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='223.07px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - non-square no-diag</text>
+</g>
+</svg>

--- a/tests/testthat/test-nonsquare.R
+++ b/tests/testthat/test-nonsquare.R
@@ -16,3 +16,37 @@ test_that("square matrices are unaffected by the non-square guard", {
   sq <- round(cor(mtcars), 1)
   expect_no_error(ggplot2::ggplot_build(ggcorrplot(sq, hc.order = TRUE, type = "lower")))
 })
+
+# show.diag = FALSE on a non-square matrix must remove genuine self-pairs by NAME,
+# not the positional diagonal (which is meaningless for m x n). Previously
+# .remove_diag() ran diag(cormat) <- NA, blanking min(m, n) arbitrary cells.
+cells <- function(p) ggplot2::ggplot_build(p)$data[[1]]
+pairs <- function(p) {
+  d <- ggplot2::ggplot_build(p)$plot$data
+  paste(d$Var1, d$Var2)
+}
+
+test_that("non-square + show.diag = FALSE with disjoint variables removes no cell", {
+  rect <- cor(mtcars[, 1:3], mtcars[, 4:7]) # 3 x 4, rows {mpg,cyl,disp} cols {hp,drat,wt,qsec}
+  # no row variable is also a column variable -> there are no self-pairs to drop
+  expect_equal(nrow(cells(ggcorrplot(rect, show.diag = FALSE))), length(rect)) # all 12 kept
+  # every cell present, in particular the positional (1,1) cell mpg~hp
+  expect_true("mpg hp" %in% pairs(ggcorrplot(rect, show.diag = FALSE)))
+})
+
+test_that("non-square + show.diag = FALSE blanks self-pairs by name, off the positional diagonal", {
+  m <- round(cor(mtcars), 1)
+  # rows are the LAST three of the five columns, so the self-pairs disp~disp,
+  # hp~hp, wt~wt sit at columns 3, 4, 5 -- NOT on the positional diagonal
+  sub <- m[c("disp", "hp", "wt"), c("mpg", "cyl", "disp", "hp", "wt")] # 3 x 5
+  p <- ggcorrplot(sub, show.diag = FALSE)
+  expect_equal(nrow(cells(p)), length(sub) - 3L) # exactly the 3 self-pairs removed
+  pr <- pairs(p)
+  expect_false(any(c("disp disp", "hp hp", "wt wt") %in% pr)) # self-pairs gone
+  expect_true("disp mpg" %in% pr) # the positional (1,1) cell (a cross-pair) survives
+})
+
+test_that("non-square + show.diag = TRUE (the default for full) keeps every cell", {
+  rect <- cor(mtcars[, 1:3], mtcars[, 4:7])
+  expect_equal(nrow(cells(ggcorrplot(rect))), length(rect)) # default show.diag path unchanged
+})

--- a/tests/testthat/test-nonsquare.R
+++ b/tests/testthat/test-nonsquare.R
@@ -50,3 +50,11 @@ test_that("non-square + show.diag = TRUE (the default for full) keeps every cell
   rect <- cor(mtcars[, 1:3], mtcars[, 4:7])
   expect_equal(nrow(cells(ggcorrplot(rect))), length(rect)) # default show.diag path unchanged
 })
+
+test_that("unnamed non-square + show.diag = FALSE keeps the historical positional removal", {
+  rect <- cor(mtcars[, 1:3], mtcars[, 4:7]) # 3 x 4
+  dimnames(rect) <- NULL
+  # no names to match self-pairs by, so the positional diagonal (min(m,n) = 3
+  # cells) is removed as before -> 12 - 3 = 9 cells
+  expect_equal(nrow(cells(ggcorrplot(rect, show.diag = FALSE))), length(rect) - 3L)
+})

--- a/tests/testthat/test-vdiffr.R
+++ b/tests/testthat/test-vdiffr.R
@@ -49,5 +49,16 @@ if (getRversion() >= "4.1") {
       title = "ggcorrplot works - insig stars",
       fig = ggcorrplot(corr, p.mat = p.mat, insig = "stars")
     )
+
+    set.seed(123)
+    # non-square matrix with show.diag = FALSE: only the genuine self-pairs
+    # (disp, hp, wt) are blanked, not the positional diagonal
+    nonsq <- round(cor(mtcars), 1)[
+      c("disp", "hp", "wt"), c("mpg", "cyl", "disp", "hp", "wt")
+    ]
+    vdiffr::expect_doppelganger(
+      title = "ggcorrplot works - non-square no-diag",
+      fig = ggcorrplot(nonsq, show.diag = FALSE, lab = TRUE)
+    )
   })
 }


### PR DESCRIPTION
`.remove_diag()` ran `diag(cormat) <- NA`, which on an m x n matrix blanks `min(m, n)` cells along the leading positional diagonal. A non-square matrix has no meaningful positional diagonal, so with `show.diag = FALSE` this wiped the wrong cells (e.g. a 3x5 submatrix whose shared variable names sit off the positional diagonal lost cross-correlations instead of its self-correlations).

The fix removes only the genuine self-pairs -- cells whose row and column name the same variable -- so a matrix with disjoint row and column variables keeps every cell. Square matrices are unaffected: they keep the positional diagonal removal and produce byte-identical output.

Reachable only via a non-square matrix with `type = "full"` and `show.diag = FALSE`; `hc.order` and the triangular layouts already error on non-square input. Refs #5, #10.

Tests: non-square + `show.diag = FALSE` with disjoint variables removes no cell; with name-overlapping variables removes exactly the self-pairs by name (not the positional diagonal); the positional (1,1) cross-pair survives; `show.diag = TRUE` keeps every cell; square matrices unchanged.