### PR TITLE
Add a palette argument for colorblind-safe diverging palettes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## New features
 
+- New argument `palette` to pick a built-in colorblind-safe diverging palette for
+  the fill gradient: `ggcorrplot(corr, palette = "RdBu")` (or `"PuOr"`). Each is
+  an 11-stop ramp with white at zero and the usual cool = negative / warm =
+  positive polarity, so it is a one-word alternative to spelling out `colors`.
+  Defaults to `NULL` (use `colors`), leaving existing calls unchanged.
+
 - New value `insig = "stars"` to mark the significant cells with significance
   stars (`***`/`**`/`*` for p < 0.001/0.01/0.05) instead of crossing out the
   insignificant ones. Works without `lab`, so `ggcorrplot(corr, p.mat = p.mat,

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -37,6 +37,12 @@
 #'   (\code{>= 2}) is spread evenly across the scale with
 #'   \code{\link[ggplot2]{scale_fill_gradientn}}, so an n-color palette (e.g.
 #'   \code{RColorBrewer::brewer.pal(11, "RdBu")}) can be passed directly.
+#' @param palette optional name of a built-in colorblind-safe diverging palette
+#'   for the fill gradient: \code{"RdBu"} or \code{"PuOr"}. A convenience
+#'   shortcut for \code{colors}: when set it supplies the gradient (an 11-stop
+#'   ramp, white at zero, cool = negative / warm = positive) and takes precedence
+#'   over \code{colors}. Defaults to \code{NULL} (use \code{colors}), so existing
+#'   calls are unchanged.
 #' @param outline.color the outline color of square or circle. Default value is
 #'   "gray".
 #' @param hc.order logical value. If TRUE, correlation matrix will be hc.ordered
@@ -239,7 +245,8 @@ ggcorrplot <- function(corr,
                        coord.fixed = TRUE,
                        lower.method = NULL,
                        upper.method = NULL,
-                       hc.rect = NULL) {
+                       hc.rect = NULL,
+                       palette = NULL) {
   type <- match.arg(type)
   method <- match.arg(method)
   # Resolve on insig[1] (not match.arg(insig)) so a caller passing the old
@@ -249,6 +256,14 @@ ggcorrplot <- function(corr,
   # "stars" made c("pch", "blank") non-identical. Scalar/partial matching and the
   # default are unchanged.
   insig <- match.arg(insig[1], c("pch", "blank", "stars"))
+  # A named colorblind-safe diverging palette is a convenience shortcut for
+  # `colors`: when set (non-NULL, the default), it supplies the fill gradient and
+  # takes precedence over `colors`. `palette = NULL` leaves `colors` untouched, so
+  # every existing call is unchanged.
+  if (!is.null(palette)) {
+    palette <- match.arg(palette, c("RdBu", "PuOr"))
+    colors <- .ggcorrplot_palette(palette)
+  }
   if (is.null(show.diag)) {
     if (type == "full") {
       show.diag <- TRUE
@@ -924,6 +939,25 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
     }
   }
   cormat
+}
+
+# Named colorblind-safe diverging palettes, as hardcoded hex vectors (the package
+# targets R >= 3.3, which predates hcl.colors(), and Imports are kept minimal, so
+# the values are not computed at run time). Each is an 11-stop ColorBrewer
+# diverging ramp with white at the center, ordered low -> high (cool = negative,
+# warm = positive) to match the default colors = c("blue", "white", "red")
+# polarity. Verified against RColorBrewer::brewer.pal(11, .) at development time.
+.ggcorrplot_palette <- function(name) {
+  switch(name,
+    RdBu = c(
+      "#053061", "#2166AC", "#4393C3", "#92C5DE", "#D1E5F0", "#F7F7F7",
+      "#FDDBC7", "#F4A582", "#D6604D", "#B2182B", "#67001F"
+    ),
+    PuOr = c(
+      "#2D004B", "#542788", "#8073AC", "#B2ABD2", "#D8DAEB", "#F7F7F7",
+      "#FEE0B6", "#FDB863", "#E08214", "#B35806", "#7F3B08"
+    )
+  )
 }
 # hc.order correlation matrix. Returns the whole hclust object (its $order gives
 # the reordering; the tree itself is needed to draw cluster rectangles, hc.rect).

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -43,7 +43,8 @@ ggcorrplot(
   coord.fixed = TRUE,
   lower.method = NULL,
   upper.method = NULL,
-  hc.rect = NULL
+  hc.rect = NULL,
+  palette = NULL
 )
 
 cor_pmat(x, ..., use = c("pairwise.complete.obs", "everything"))
@@ -187,6 +188,13 @@ diagonal. Requires \code{hc.order = TRUE} and \code{type = "full"} (the boxes
 span whole diagonal blocks). \code{NULL} (default) draws no rectangles. For a
 custom box style, add your own \code{annotate("rect", ...)} to the returned
 plot.}
+
+\item{palette}{optional name of a built-in colorblind-safe diverging palette
+for the fill gradient: \code{"RdBu"} or \code{"PuOr"}. A convenience
+shortcut for \code{colors}: when set it supplies the gradient (an 11-stop
+ramp, white at zero, cool = negative / warm = positive) and takes precedence
+over \code{colors}. Defaults to \code{NULL} (use \code{colors}), so existing
+calls are unchanged.}
 
 \item{x}{numeric matrix or data frame}
 

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-palette-rdbu.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-palette-rdbu.svg
@@ -1,0 +1,345 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw'>
+    <rect x='50.82' y='0.00' width='618.36' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw)'>
+<rect x='50.82' y='0.00' width='618.36' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg=='>
+    <rect x='86.59' y='22.78' width='517.27' height='517.27' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg==)'>
+<polyline points='86.59,512.35 603.86,512.35 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,466.16 603.86,466.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,419.98 603.86,419.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,373.79 603.86,373.79 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,327.61 603.86,327.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,281.42 603.86,281.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,235.24 603.86,235.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,189.05 603.86,189.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,142.86 603.86,142.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,96.68 603.86,96.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,50.49 603.86,50.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='114.30,540.06 114.30,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='160.48,540.06 160.48,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='206.67,540.06 206.67,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='252.85,540.06 252.85,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='299.04,540.06 299.04,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='345.22,540.06 345.22,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='391.41,540.06 391.41,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.59,540.06 437.59,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='483.78,540.06 483.78,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='529.96,540.06 529.96,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='576.15,540.06 576.15,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<rect x='91.21' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='137.39' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #134A86;' />
+<rect x='183.58' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #2166AC;' />
+<rect x='229.76' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #2166AC;' />
+<rect x='275.95' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='322.13' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #134A86;' />
+<rect x='368.32' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F4A582;' />
+<rect x='414.50' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='460.69' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D6604D;' />
+<rect x='506.87' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E68367;' />
+<rect x='553.06' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='91.21' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #134A86;' />
+<rect x='137.39' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='183.58' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8C0A25;' />
+<rect x='229.76' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2182B;' />
+<rect x='275.95' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='322.13' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2182B;' />
+<rect x='368.32' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='414.50' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #2166AC;' />
+<rect x='460.69' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #6EACD1;' />
+<rect x='506.87' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #6EACD1;' />
+<rect x='553.06' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E68367;' />
+<rect x='91.21' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #2166AC;' />
+<rect x='137.39' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8C0A25;' />
+<rect x='183.58' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='229.76' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2182B;' />
+<rect x='275.95' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='322.13' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8C0A25;' />
+<rect x='368.32' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #92C5DE;' />
+<rect x='414.50' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='460.69' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='506.87' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='553.06' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F4A582;' />
+<rect x='91.21' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #2166AC;' />
+<rect x='137.39' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2182B;' />
+<rect x='183.58' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2182B;' />
+<rect x='229.76' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='275.95' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #92C5DE;' />
+<rect x='322.13' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='368.32' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='414.50' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='460.69' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E5F0;' />
+<rect x='506.87' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E4EEF4;' />
+<rect x='553.06' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='91.21' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='137.39' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='183.58' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='229.76' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #92C5DE;' />
+<rect x='275.95' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='322.13' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='368.32' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FBE9DF;' />
+<rect x='414.50' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F4A582;' />
+<rect x='460.69' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='506.87' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='553.06' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E4EEF4;' />
+<rect x='91.21' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #134A86;' />
+<rect x='137.39' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2182B;' />
+<rect x='183.58' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #8C0A25;' />
+<rect x='229.76' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='275.95' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='322.13' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='368.32' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E5F0;' />
+<rect x='414.50' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='460.69' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='506.87' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='553.06' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F4A582;' />
+<rect x='91.21' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F4A582;' />
+<rect x='137.39' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='183.58' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #92C5DE;' />
+<rect x='229.76' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='275.95' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FBE9DF;' />
+<rect x='322.13' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E5F0;' />
+<rect x='368.32' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='414.50' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='460.69' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E5F0;' />
+<rect x='506.87' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E5F0;' />
+<rect x='553.06' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='91.21' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='137.39' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #2166AC;' />
+<rect x='183.58' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='229.76' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='275.95' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F4A582;' />
+<rect x='322.13' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='368.32' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='414.50' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='460.69' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FDDBC7;' />
+<rect x='506.87' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FDDBC7;' />
+<rect x='553.06' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='91.21' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D6604D;' />
+<rect x='137.39' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #6EACD1;' />
+<rect x='183.58' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='229.76' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E5F0;' />
+<rect x='275.95' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='322.13' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='368.32' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E5F0;' />
+<rect x='414.50' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FDDBC7;' />
+<rect x='460.69' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='506.87' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2182B;' />
+<rect x='553.06' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FBE9DF;' />
+<rect x='91.21' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E68367;' />
+<rect x='137.39' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #6EACD1;' />
+<rect x='183.58' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='229.76' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E4EEF4;' />
+<rect x='275.95' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='322.13' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='368.32' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E5F0;' />
+<rect x='414.50' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FDDBC7;' />
+<rect x='460.69' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #B2182B;' />
+<rect x='506.87' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<rect x='553.06' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FAC0A4;' />
+<rect x='91.21' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='137.39' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E68367;' />
+<rect x='183.58' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F4A582;' />
+<rect x='229.76' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #C4413C;' />
+<rect x='275.95' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #E4EEF4;' />
+<rect x='322.13' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #F4A582;' />
+<rect x='368.32' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #347CB8;' />
+<rect x='414.50' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #4393C3;' />
+<rect x='460.69' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FBE9DF;' />
+<rect x='506.87' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FAC0A4;' />
+<rect x='553.06' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #FFFFFF; stroke-linecap: butt; stroke-linejoin: miter; fill: #67001F;' />
+<text x='114.30' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='160.48' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.9</text>
+<text x='206.67' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='252.85' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='299.04' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='345.22' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.9</text>
+<text x='391.41' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='437.59' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='483.78' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='529.96' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='576.15' y='516.26' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='114.30' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.9</text>
+<text x='160.48' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='206.67' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='252.85' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='299.04' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='345.22' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='391.41' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='437.59' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='483.78' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='529.96' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='576.15' y='470.08' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='114.30' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='160.48' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='206.67' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='252.85' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='299.04' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='345.22' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='391.41' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.4</text>
+<text x='437.59' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='483.78' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='529.96' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='576.15' y='423.89' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='114.30' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='160.48' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='206.67' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='252.85' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='299.04' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.4</text>
+<text x='345.22' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='391.41' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='437.59' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='483.78' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='529.96' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.1</text>
+<text x='576.15' y='377.71' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='114.30' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='160.48' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='206.67' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='252.85' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.4</text>
+<text x='299.04' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='345.22' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='391.41' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='437.59' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='483.78' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='529.96' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='576.15' y='331.52' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.1</text>
+<text x='114.30' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.9</text>
+<text x='160.48' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='206.67' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.9</text>
+<text x='252.85' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='299.04' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='345.22' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='391.41' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='437.59' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='483.78' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='529.96' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='576.15' y='285.34' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='114.30' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='160.48' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='206.67' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.4</text>
+<text x='252.85' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='299.04' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='345.22' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='391.41' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='437.59' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='483.78' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='529.96' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='576.15' y='239.15' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='114.30' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='160.48' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.8</text>
+<text x='206.67' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='252.85' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='299.04' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='345.22' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='391.41' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='437.59' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='483.78' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='529.96' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='576.15' y='192.97' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='114.30' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.6</text>
+<text x='160.48' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='206.67' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='252.85' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='299.04' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='345.22' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='391.41' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='437.59' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='483.78' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='529.96' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='576.15' y='146.78' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='114.30' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='160.48' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='206.67' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='252.85' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.1</text>
+<text x='299.04' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='345.22' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='391.41' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.2</text>
+<text x='437.59' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='483.78' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.8</text>
+<text x='529.96' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='576.15' y='100.60' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='114.30' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='160.48' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='206.67' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='252.85' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.7</text>
+<text x='299.04' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.1</text>
+<text x='345.22' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.4</text>
+<text x='391.41' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.7</text>
+<text x='437.59' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='19.61px' lengthAdjust='spacingAndGlyphs'>-0.6</text>
+<text x='483.78' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='529.96' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='15.82px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<text x='576.15' y='54.41' text-anchor='middle' style='font-size: 11.38px; font-family: sans;' textLength='6.33px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='81.66' y='516.47' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='81.66' y='470.29' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='81.66' y='424.10' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='81.66' y='377.92' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text x='81.66' y='331.73' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='81.66' y='285.55' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text x='81.66' y='239.36' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text x='81.66' y='193.18' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text x='81.66' y='146.99' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text x='81.66' y='100.81' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text x='81.66' y='54.62' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text transform='translate(120.14,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text transform='translate(166.32,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text transform='translate(212.51,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(258.69,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text transform='translate(304.88,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text transform='translate(351.06,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(397.25,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text transform='translate(443.43,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text transform='translate(489.62,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text transform='translate(535.80,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text transform='translate(581.99,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
+<image width='17.28' height='86.40' x='620.30' y='245.89' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAABCElEQVQ4jY2RwXUEIQxDZXn7SHnpv4CxcgAMZiDJxc/Wl8S+WXzjSyQAuhnWzQASBrqhn44BpsV3X01YSZxBKZjAPgbyY6D5HATpBhpTy42bRvZtSdTBtLxAKViGs4NeOs4OrJ58xTqt2ZO2JWoLNp8NrQMf2wK8ZM3PCdhBa6AUoCZWs48Ws3WT8QyQQBvADVwTTbucgoESQEmgADCEvjVNAKOdBaw+gAFlFbJKq2Wtqq+1RL6mkY18aNueE4jfEvN8ZbfmS1WLhcAI1LPQ56hlyy3xOjG2pPuWP1KR3zQE4qC1UUEctL98+R9NTeOTLOYIUPGMoXkGiAmmr1r+Q+/aOBEBSt3yAxhIj/va1JMWAAAAAElFTkSuQmCC'/>
+<polyline points='634.12,332.14 637.58,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,310.61 637.58,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,289.09 637.58,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,267.56 637.58,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,246.03 637.58,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,332.14 620.30,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,310.61 620.30,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,289.09 620.30,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,267.56 620.30,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,246.03 620.30,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='643.06' y='335.17' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='643.06' y='313.64' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='643.06' y='292.11' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='643.06' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='643.06' y='249.06' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='86.59' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='184.91px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - palette RdBu</text>
+</g>
+</svg>

--- a/tests/testthat/test-palette.R
+++ b/tests/testthat/test-palette.R
@@ -1,0 +1,49 @@
+# palette = : named colorblind-safe diverging palettes as a convenience shortcut
+# for colors. Default NULL leaves colors (and every existing call) unchanged.
+
+corr <- round(cor(mtcars), 1)
+fill <- function(p) ggplot2::ggplot_build(p)$data[[1]]
+
+test_that(".ggcorrplot_palette returns the pinned colorblind-safe hex (visual contract)", {
+  rdbu <- .ggcorrplot_palette("RdBu")
+  puor <- .ggcorrplot_palette("PuOr")
+  expect_length(rdbu, 11)
+  expect_length(puor, 11)
+  # low = cool, center = white, high = warm (matches the default blue/white/red polarity)
+  expect_identical(rdbu[c(1, 6, 11)], c("#053061", "#F7F7F7", "#67001F"))
+  expect_identical(puor[c(1, 6, 11)], c("#2D004B", "#F7F7F7", "#7F3B08"))
+})
+
+test_that("palette = 'RdBu' is exactly equivalent to passing its hex vector to colors", {
+  expect_equal(
+    fill(ggcorrplot(corr, palette = "RdBu")),
+    fill(ggcorrplot(corr, colors = .ggcorrplot_palette("RdBu")))
+  )
+})
+
+test_that("palette = NULL (the default) leaves the fill unchanged, and RdBu differs from it", {
+  expect_equal(fill(ggcorrplot(corr)), fill(ggcorrplot(corr, palette = NULL)))
+  # the RdBu ramp is genuinely different from the default blue/white/red
+  expect_false(isTRUE(all.equal(
+    fill(ggcorrplot(corr))$fill,
+    fill(ggcorrplot(corr, palette = "RdBu"))$fill
+  )))
+})
+
+test_that("palette takes precedence over colors when both are supplied", {
+  expect_equal(
+    fill(ggcorrplot(corr, palette = "RdBu", colors = c("blue", "white", "red"))),
+    fill(ggcorrplot(corr, palette = "RdBu"))
+  )
+})
+
+test_that("an unknown palette errors", {
+  expect_error(ggcorrplot(corr, palette = "viridis"))
+  expect_error(ggcorrplot(corr, palette = "rdbu")) # match.arg is case-sensitive
+})
+
+test_that("palette also colors a mixed 'number' triangle (same colors source)", {
+  # the mixed number colour scale reads the same resolved colors
+  p <- ggcorrplot(corr, lower.method = "number", upper.method = "circle", palette = "RdBu")
+  expect_silent(ggplot2::ggplot_build(p))
+})

--- a/tests/testthat/test-vdiffr.R
+++ b/tests/testthat/test-vdiffr.R
@@ -60,5 +60,11 @@ if (getRversion() >= "4.1") {
       title = "ggcorrplot works - non-square no-diag",
       fig = ggcorrplot(nonsq, show.diag = FALSE, lab = TRUE)
     )
+
+    set.seed(123)
+    vdiffr::expect_doppelganger(
+      title = "ggcorrplot works - palette RdBu",
+      fig = ggcorrplot(corr, palette = "RdBu", outline.color = "white", lab = TRUE)
+    )
   })
 }


### PR DESCRIPTION
New `palette` argument selects a built-in **colorblind-safe diverging** fill gradient without spelling out `colors`:

```r
ggcorrplot(corr, palette = "RdBu")   # or "PuOr"
```

Each is an 11-stop diverging ramp with white at zero and the usual cool = negative / warm = positive polarity, so it matches the default blue/white/red orientation but reads better and is safe for colorblind viewers. The hex is hardcoded (the package targets R >= 3.3, which predates `hcl.colors()`, and Imports stay minimal) and verified against the reference diverging-palette hex values at development time.

- Default `palette = NULL` uses `colors` — **every existing call is byte-identical** (64/64 combinations verified vs `origin/master`).
- When set, `palette` takes precedence over `colors` and also colors a mixed "number" triangle (single resolved source).
- Structural tests pin the exact hex (the visual contract), the equivalence to passing the vector to `colors`, the unchanged default, precedence, and error on an unknown name. `R CMD check --as-cran` clean (no warnings; codoc OK).