### PR TITLE
Add scale.square to size squares by correlation magnitude

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## New features
 
+- New argument `scale.square` to size the squares by the absolute correlation
+  when `method = "square"`: `ggcorrplot(corr, scale.square = TRUE)` scales each
+  square (larger = stronger correlation) on top of the fill color, the classic
+  corrplot size-scaled square look. Defaults to `FALSE` (constant full-cell
+  squares, unchanged); has no effect for `method = "circle"` (circles are always
+  sized).
+
 - New argument `preset` for publication-grade output in one token:
   `ggcorrplot(corr, preset = "publication")` sets white cell outlines and the
   colorblind-safe `"RdBu"` palette. It only fills arguments you did not supply, so

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -6,6 +6,12 @@
 #' @param corr the correlation matrix to visualize
 #' @param method character, the visualization method of correlation matrix to be
 #'   used. Allowed values are "square" (default), "circle".
+#' @param scale.square logical. If \code{TRUE} and \code{method = "square"}, the
+#'   squares are sized by the absolute correlation (larger square = stronger
+#'   correlation), in addition to the fill color -- the classic corrplot
+#'   size-scaled square look. Defaults to \code{FALSE} (constant full-cell
+#'   squares, the current behavior). Has no effect for \code{method = "circle"}
+#'   (circles are always sized). Uses \code{circle.scale} to tune the size range.
 #' @param lower.method,upper.method character, an optional per-triangle glyph for
 #'   a mixed layout: one of "square", "circle" or "number" (the coefficient drawn
 #'   as text, colored by its value on the same scale as the fill, so coefficients
@@ -258,7 +264,8 @@ ggcorrplot <- function(corr,
                        hc.rect = NULL,
                        palette = NULL,
                        preset = NULL,
-                       hc.rect.col = "gray30") {
+                       hc.rect.col = "gray30",
+                       scale.square = FALSE) {
   type <- match.arg(type)
   method <- match.arg(method)
   # Resolve on insig[1] (not match.arg(insig)) so a caller passing the old
@@ -396,7 +403,8 @@ ggcorrplot <- function(corr,
       corr, lower.method, upper.method,
       outline.color = outline.color, circle.scale = circle.scale,
       lab_size = lab_size, tl.cex = tl.cex, tl.col = tl.col,
-      digits = digits, nsmall = nsmall, leading.zero = leading.zero
+      digits = digits, nsmall = nsmall, leading.zero = leading.zero,
+      scale.square = scale.square
     )
   } else {
     p <-
@@ -407,7 +415,10 @@ ggcorrplot <- function(corr,
 
     # modification based on method (extracted so the mixed-method path can request
     # a different glyph per triangle from the same builder, P0.0)
-    p <- p + .method_layer(method, outline.color = outline.color, circle.scale = circle.scale)
+    p <- p + .method_layer(method,
+      outline.color = outline.color, circle.scale = circle.scale,
+      scale.square = scale.square
+    )
   }
 
   # adding colors
@@ -798,9 +809,22 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
 # Build the glyph layer(s) for a given method. Returns a list of ggplot
 # components so the caller can add them with a single `+` (and so the
 # mixed-method path can request a different glyph per triangle, P0.0).
-.method_layer <- function(method, outline.color, circle.scale) {
-  if (method == "square") {
+.method_layer <- function(method, outline.color, circle.scale, scale.square = FALSE) {
+  if (method == "square" && !scale.square) {
     list(ggplot2::geom_tile(color = outline.color))
+  } else if (method == "square" && scale.square) {
+    # size-scaled squares (corrplot-style): a filled square (shape 22) whose size
+    # encodes |r|, mirroring the sized-circle glyph. Only reached when the caller
+    # opts in with scale.square = TRUE, so the default square heatmap is unchanged.
+    list(
+      ggplot2::geom_point(
+        color = outline.color,
+        shape = 22,
+        ggplot2::aes(size = .data[["abs_corr"]])
+      ),
+      ggplot2::scale_size(range = c(4, 10) * circle.scale),
+      ggplot2::guides(size = "none")
+    )
   } else if (method == "circle") {
     list(
       ggplot2::geom_point(
@@ -850,7 +874,7 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
 # variable name. Returns a list of ggplot components.
 .mixed_layers <- function(df, lower.method, upper.method,
                           outline.color, circle.scale, lab_size, tl.cex, tl.col,
-                          digits, nsmall, leading.zero) {
+                          digits, nsmall, leading.zero, scale.square = FALSE) {
   xi <- as.integer(df$Var1)
   yi <- as.integer(df$Var2)
   regions <- list(
@@ -860,19 +884,26 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
   )
 
   layers <- list()
-  has_circle <- FALSE
+  has_sized <- FALSE
   for (r in regions) {
     d <- r$data
     if (nrow(d) == 0) next
     m <- r$method
-    if (m == "square") {
+    if (m == "square" && !scale.square) {
       layers <- c(layers, list(ggplot2::geom_tile(
         data = d,
         mapping = ggplot2::aes(fill = .data[["value"]]),
         color = outline.color
       )))
+    } else if (m == "square" && scale.square) {
+      has_sized <- TRUE
+      layers <- c(layers, list(ggplot2::geom_point(
+        data = d,
+        mapping = ggplot2::aes(fill = .data[["value"]], size = .data[["abs_corr"]]),
+        color = outline.color, shape = 22
+      )))
     } else if (m == "circle") {
-      has_circle <- TRUE
+      has_sized <- TRUE
       layers <- c(layers, list(ggplot2::geom_point(
         data = d,
         mapping = ggplot2::aes(fill = .data[["value"]], size = .data[["abs_corr"]]),
@@ -895,7 +926,7 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
     }
   }
 
-  if (has_circle) {
+  if (has_sized) {
     layers <- c(layers, list(
       ggplot2::scale_size(range = c(4, 10) * circle.scale),
       ggplot2::guides(size = "none")

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -12,6 +12,8 @@
 #'   size-scaled square look. Defaults to \code{FALSE} (constant full-cell
 #'   squares, the current behavior). Has no effect for \code{method = "circle"}
 #'   (circles are always sized). Uses \code{circle.scale} to tune the size range.
+#'   As with \code{method = "circle"}, coefficient labels (\code{lab = TRUE}) are
+#'   drawn at full size and may overflow the smallest squares.
 #' @param lower.method,upper.method character, an optional per-triangle glyph for
 #'   a mixed layout: one of "square", "circle" or "number" (the coefficient drawn
 #'   as text, colored by its value on the same scale as the fill, so coefficients

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -216,7 +216,9 @@ squares are sized by the absolute correlation (larger square = stronger
 correlation), in addition to the fill color -- the classic corrplot
 size-scaled square look. Defaults to \code{FALSE} (constant full-cell
 squares, the current behavior). Has no effect for \code{method = "circle"}
-(circles are always sized). Uses \code{circle.scale} to tune the size range.}
+(circles are always sized). Uses \code{circle.scale} to tune the size range.
+As with \code{method = "circle"}, coefficient labels (\code{lab = TRUE}) are
+drawn at full size and may overflow the smallest squares.}
 
 \item{x}{numeric matrix or data frame}
 

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -46,7 +46,8 @@ ggcorrplot(
   hc.rect = NULL,
   palette = NULL,
   preset = NULL,
-  hc.rect.col = "gray30"
+  hc.rect.col = "gray30",
+  scale.square = FALSE
 )
 
 cor_pmat(x, ..., use = c("pairwise.complete.obs", "everything"))
@@ -209,6 +210,13 @@ supply, so any argument you pass explicitly (e.g. \code{outline.color},
 Defaults to \code{"gray30"}; set it to any color that suits your palette
 (e.g. \code{"black"} for a bolder box, or \code{"white"}). Only used when
 \code{hc.rect} is set.}
+
+\item{scale.square}{logical. If \code{TRUE} and \code{method = "square"}, the
+squares are sized by the absolute correlation (larger square = stronger
+correlation), in addition to the fill color -- the classic corrplot
+size-scaled square look. Defaults to \code{FALSE} (constant full-cell
+squares, the current behavior). Has no effect for \code{method = "circle"}
+(circles are always sized). Uses \code{circle.scale} to tune the size range.}
 
 \item{x}{numeric matrix or data frame}
 

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-scale-square.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-scale-square.svg
@@ -1,0 +1,224 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw'>
+    <rect x='50.82' y='0.00' width='618.36' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw)'>
+<rect x='50.82' y='0.00' width='618.36' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg=='>
+    <rect x='86.59' y='22.78' width='517.27' height='517.27' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg==)'>
+<polyline points='86.59,512.35 603.86,512.35 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,466.16 603.86,466.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,419.98 603.86,419.98 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,373.79 603.86,373.79 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,327.61 603.86,327.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,281.42 603.86,281.42 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,235.24 603.86,235.24 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,189.05 603.86,189.05 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,142.86 603.86,142.86 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,96.68 603.86,96.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='86.59,50.49 603.86,50.49 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='114.30,540.06 114.30,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='160.48,540.06 160.48,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='206.67,540.06 206.67,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='252.85,540.06 252.85,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='299.04,540.06 299.04,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='345.22,540.06 345.22,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='391.41,540.06 391.41,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='437.59,540.06 437.59,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='483.78,540.06 483.78,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='529.96,540.06 529.96,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='576.15,540.06 576.15,22.78 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' />
+<rect x='104.53' y='502.58' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='151.04' y='502.90' width='18.89' height='18.89' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #502BFF;' />
+<rect x='197.57' y='503.25' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #7145FF;' />
+<rect x='243.75' y='503.25' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #7145FF;' />
+<rect x='290.31' y='503.62' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='335.78' y='502.90' width='18.89' height='18.89' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #502BFF;' />
+<rect x='384.04' y='504.97' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFB299;' />
+<rect x='428.87' y='503.62' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='475.45' y='504.02' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF8969;' />
+<rect x='522.09' y='504.47' width='15.76' height='15.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF9E81;' />
+<rect x='567.82' y='504.02' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='104.85' y='456.72' width='18.89' height='18.89' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #502BFF;' />
+<rect x='150.71' y='456.39' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='197.22' y='456.72' width='18.89' height='18.89' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF3E22;' />
+<rect x='243.75' y='457.06' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF5B3A;' />
+<rect x='290.31' y='457.43' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='336.12' y='457.06' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF5B3A;' />
+<rect x='383.08' y='457.84' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='428.49' y='457.06' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #7145FF;' />
+<rect x='475.90' y='458.28' width='15.76' height='15.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #B38BFF;' />
+<rect x='522.09' y='458.28' width='15.76' height='15.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #B38BFF;' />
+<rect x='568.27' y='458.28' width='15.76' height='15.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF9E81;' />
+<rect x='105.20' y='410.88' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #7145FF;' />
+<rect x='151.04' y='410.53' width='18.89' height='18.89' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF3E22;' />
+<rect x='196.90' y='410.21' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='243.75' y='410.88' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF5B3A;' />
+<rect x='290.31' y='411.25' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='335.78' y='410.53' width='18.89' height='18.89' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF3E22;' />
+<rect x='384.04' y='412.60' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #C4A2FF;' />
+<rect x='428.87' y='411.25' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='475.45' y='411.65' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='521.64' y='411.65' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='568.78' y='412.60' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFB299;' />
+<rect x='105.20' y='364.69' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #7145FF;' />
+<rect x='151.38' y='364.69' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF5B3A;' />
+<rect x='197.57' y='364.69' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF5B3A;' />
+<rect x='243.08' y='364.02' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='291.67' y='366.42' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #C4A2FF;' />
+<rect x='336.50' y='365.06' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='382.68' y='365.06' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='428.87' y='365.06' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='477.79' y='367.80' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #E3D0FF;' />
+<rect x='525.87' y='369.69' width='8.19' height='8.19' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #F2E7FF;' />
+<rect x='567.42' y='365.06' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='105.57' y='318.88' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='151.75' y='318.88' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='197.94' y='318.88' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='245.48' y='320.23' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #C4A2FF;' />
+<rect x='289.27' y='317.84' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='336.50' y='318.88' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='387.31' y='323.51' width='8.19' height='8.19' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFECE5;' />
+<rect x='430.22' y='320.23' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFB299;' />
+<rect x='475.05' y='318.88' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='521.24' y='318.88' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='572.05' y='323.51' width='8.19' height='8.19' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #F2E7FF;' />
+<rect x='104.85' y='271.97' width='18.89' height='18.89' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #502BFF;' />
+<rect x='151.38' y='272.32' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF5B3A;' />
+<rect x='197.22' y='271.97' width='18.89' height='18.89' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF3E22;' />
+<rect x='244.13' y='272.69' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='290.31' y='272.69' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='335.45' y='271.65' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='385.42' y='275.43' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #E3D0FF;' />
+<rect x='429.27' y='273.10' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='475.05' y='272.69' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='521.64' y='273.10' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='568.78' y='274.05' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFB299;' />
+<rect x='106.93' y='227.86' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFB299;' />
+<rect x='152.16' y='226.91' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='199.30' y='227.86' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #C4A2FF;' />
+<rect x='244.13' y='226.51' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='294.94' y='231.14' width='8.19' height='8.19' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFECE5;' />
+<rect x='339.24' y='229.25' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #E3D0FF;' />
+<rect x='381.64' y='225.47' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='428.87' y='226.51' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='477.79' y='229.25' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #E3D0FF;' />
+<rect x='523.98' y='229.25' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #E3D0FF;' />
+<rect x='567.42' y='226.51' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='105.57' y='180.32' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='151.38' y='179.95' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #7145FF;' />
+<rect x='197.94' y='180.32' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='244.13' y='180.32' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='291.67' y='181.68' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFB299;' />
+<rect x='336.90' y='180.72' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='382.68' y='180.32' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='427.82' y='179.28' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='477.79' y='183.06' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFD9CB;' />
+<rect x='523.98' y='183.06' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFD9CB;' />
+<rect x='567.82' y='180.72' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='105.97' y='134.54' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF8969;' />
+<rect x='152.61' y='134.99' width='15.76' height='15.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #B38BFF;' />
+<rect x='198.34' y='134.54' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='246.87' y='136.88' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #E3D0FF;' />
+<rect x='290.31' y='134.14' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='336.50' y='134.14' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='385.42' y='136.88' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #E3D0FF;' />
+<rect x='431.61' y='136.88' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFD9CB;' />
+<rect x='474.01' y='133.09' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='520.86' y='133.76' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF5B3A;' />
+<rect x='572.05' y='138.77' width='8.19' height='8.19' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFECE5;' />
+<rect x='106.42' y='88.80' width='15.76' height='15.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF9E81;' />
+<rect x='152.61' y='88.80' width='15.76' height='15.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #B38BFF;' />
+<rect x='198.34' y='88.35' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='248.76' y='92.58' width='8.19' height='8.19' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #F2E7FF;' />
+<rect x='290.31' y='87.95' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='336.90' y='88.35' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='385.42' y='90.69' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #E3D0FF;' />
+<rect x='431.61' y='90.69' width='11.98' height='11.98' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFD9CB;' />
+<rect x='474.68' y='87.58' width='18.20' height='18.20' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF5B3A;' />
+<rect x='520.19' y='86.91' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+<rect x='569.38' y='89.91' width='13.54' height='13.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFC6B2;' />
+<rect x='105.97' y='42.17' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='152.61' y='42.62' width='15.76' height='15.76' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF9E81;' />
+<rect x='199.30' y='43.12' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFB299;' />
+<rect x='244.13' y='41.77' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF7352;' />
+<rect x='294.94' y='46.40' width='8.19' height='8.19' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #F2E7FF;' />
+<rect x='337.85' y='43.12' width='14.74' height='14.74' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFB299;' />
+<rect x='382.68' y='41.77' width='17.46' height='17.46' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #8A5DFF;' />
+<rect x='429.27' y='42.17' width='16.65' height='16.65' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #A074FF;' />
+<rect x='479.68' y='46.40' width='8.19' height='8.19' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFECE5;' />
+<rect x='523.19' y='43.72' width='13.54' height='13.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FFC6B2;' />
+<rect x='566.38' y='40.72' width='19.54' height='19.54' style='stroke-width: 0.71; stroke: #FFFFFF; fill: #FF0000;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='81.66' y='516.47' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='81.66' y='470.29' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='81.66' y='424.10' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='81.66' y='377.92' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text x='81.66' y='331.73' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='81.66' y='285.55' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text x='81.66' y='239.36' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text x='81.66' y='193.18' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text x='81.66' y='146.99' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text x='81.66' y='100.81' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text x='81.66' y='54.62' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text transform='translate(120.14,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text transform='translate(166.32,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text transform='translate(212.51,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(258.69,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text transform='translate(304.88,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text transform='translate(351.06,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(397.25,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text transform='translate(443.43,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text transform='translate(489.62,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text transform='translate(535.80,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text transform='translate(581.99,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
+<image width='17.28' height='86.40' x='620.30' y='245.89' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAsUlEQVQ4jbWPwQ7DIAxDH2aTpv3/t05aW2CngWChTSvtYjmxYwMFingK8YiIewMhYkTchIgGyGLhOzaI/S60cTAHRNCvOlwE68Jix5b5bZ8Srlm8ve2DB+O0cn/se91tjo4zz/ifxfs+AioFVHKFMmEcW/ZTcBZ58y6e5WtRjrN8Ws3GS62ivBtlqr0wDciDz2nJRtEgmKOxS3WXhl1lFmypY2tlywZaEui9gV4rAKV8ANuwLHQSilYnAAAAAElFTkSuQmCC'/>
+<polyline points='634.12,332.14 637.58,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,310.61 637.58,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,289.09 637.58,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,267.56 637.58,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,246.03 637.58,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,332.14 620.30,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,310.61 620.30,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,289.09 620.30,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,267.56 620.30,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,246.03 620.30,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='643.06' y='335.17' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='643.06' y='313.64' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='643.06' y='292.11' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='643.06' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='643.06' y='249.06' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='86.59' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='183.44px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - scale square</text>
+</g>
+</svg>

--- a/tests/testthat/test-scale-square.R
+++ b/tests/testthat/test-scale-square.R
@@ -1,0 +1,49 @@
+# scale.square: size-scaled squares (corrplot-style) for method = "square".
+# Default FALSE keeps method = "square" a constant full-cell geom_tile.
+
+corr <- round(cor(mtcars), 1)
+geom1 <- function(p) class(p$layers[[1]]$geom)[1]
+shape1 <- function(p) p$layers[[1]]$aes_params$shape
+
+test_that("scale.square defaults to FALSE: method = 'square' stays a full tile", {
+  p <- ggcorrplot(corr)
+  expect_identical(geom1(p), "GeomTile")
+  # explicit FALSE == implicit default (byte-identical built data)
+  expect_equal(
+    ggplot2::ggplot_build(ggcorrplot(corr))$data,
+    ggplot2::ggplot_build(ggcorrplot(corr, scale.square = FALSE))$data
+  )
+})
+
+test_that("scale.square = TRUE draws size-scaled squares (shape 22, sized by |r|)", {
+  p <- ggcorrplot(corr, scale.square = TRUE)
+  expect_identical(geom1(p), "GeomPoint")
+  expect_identical(shape1(p), 22)
+  # the point size maps to abs_corr (magnitude), and there is a size scale
+  b <- ggplot2::ggplot_build(p)
+  expect_true("size" %in% names(b$data[[1]]))
+  # stronger correlations -> larger size than weak ones
+  pd <- b$plot$data
+  szmap <- b$data[[1]]$size
+  expect_gt(max(szmap), min(szmap)) # sizes actually vary
+})
+
+test_that("scale.square has no effect for method = 'circle'", {
+  a <- ggcorrplot(corr, method = "circle")
+  b <- ggcorrplot(corr, method = "circle", scale.square = TRUE)
+  expect_equal(shape1(a), 21)
+  expect_equal(shape1(b), 21) # still circles, unchanged
+  expect_equal(
+    ggplot2::ggplot_build(a)$data,
+    ggplot2::ggplot_build(b)$data
+  )
+})
+
+test_that("scale.square sizes the square region in a mixed layout", {
+  # a mixed layout with a 'square' triangle -> that triangle becomes sized squares
+  p <- ggcorrplot(corr, lower.method = "square", upper.method = "number", scale.square = TRUE)
+  geoms <- vapply(p$layers, function(l) class(l$geom)[1], "")
+  expect_true("GeomPoint" %in% geoms) # the square triangle is now a sized point layer
+  sq <- p$layers[[which(geoms == "GeomPoint")[1]]]
+  expect_identical(sq$aes_params$shape, 22)
+})

--- a/tests/testthat/test-vdiffr.R
+++ b/tests/testthat/test-vdiffr.R
@@ -72,5 +72,11 @@ if (getRversion() >= "4.1") {
       title = "ggcorrplot works - preset publication",
       fig = ggcorrplot(corr, preset = "publication", lab = TRUE)
     )
+
+    set.seed(123)
+    vdiffr::expect_doppelganger(
+      title = "ggcorrplot works - scale square",
+      fig = ggcorrplot(corr, scale.square = TRUE, outline.color = "white")
+    )
   })
 }

--- a/vignettes/publication-ready-correlation-plots.Rmd
+++ b/vignettes/publication-ready-correlation-plots.Rmd
@@ -84,6 +84,16 @@ familiar corrplot look, drawn in ggplot2.
 ggcorrplot(corr, method = "circle", hc.order = TRUE, type = "upper", outline.color = "white")
 ```
 
+# Size-scaled squares
+
+`scale.square = TRUE` sizes the squares by the absolute correlation, so magnitude is encoded by both area
+and color at once — the classic corrplot square look. Near-zero cells shrink away and the strong
+correlations dominate, which reads well for large matrices and for colorblind viewers.
+
+```{r scale-square, fig.width = 6, fig.height = 5.4}
+ggcorrplot(corr, scale.square = TRUE, hc.order = TRUE, outline.color = "white")
+```
+
 # A colorblind-safe palette
 
 `preset = "publication"` is a one-token beautiful default (white separators + the colorblind-safe RdBu

--- a/vignettes/publication-ready-correlation-plots.Rmd
+++ b/vignettes/publication-ready-correlation-plots.Rmd
@@ -87,8 +87,8 @@ ggcorrplot(corr, method = "circle", hc.order = TRUE, type = "upper", outline.col
 # Size-scaled squares
 
 `scale.square = TRUE` sizes the squares by the absolute correlation, so magnitude is encoded by both area
-and color at once — the classic corrplot square look. Near-zero cells shrink away and the strong
-correlations dominate, which reads well for large matrices and for colorblind viewers.
+and color at once — the classic corrplot square look. Near-zero cells shrink to small squares while the
+strong correlations dominate, which reads well for large matrices and for colorblind viewers.
 
 ```{r scale-square, fig.width = 6, fig.height = 5.4}
 ggcorrplot(corr, scale.square = TRUE, hc.order = TRUE, outline.color = "white")


### PR DESCRIPTION
New `scale.square` argument (default `FALSE`, appended at the end of the signature). When `TRUE` with `method = "square"`, the squares are **sized by the absolute correlation** (larger square = stronger), in addition to the fill color, mirroring the sized-circle glyph (a `shape = 22` point that honors `size`, reusing `circle.scale` and the existing `abs_corr`).

```r
ggcorrplot(corr, scale.square = TRUE, hc.order = TRUE)
```

- Default `FALSE` keeps `method = "square"` a constant full-cell tile — **every existing call is byte-identical** (64/64 combinations verified vs `origin/master`; explicit `scale.square = FALSE` reproduces the default exactly).
- Chosen as a new argument (not a new `method` value) so `method`'s partial-matching is untouched — `method="s"`/`"c"` still resolve as before; no existing argument starts with "scale", so no abbreviation clash.
- Has no effect for `method = "circle"` (circles are always sized); also sizes a `"square"` region in the mixed layout.
- Structural tests + vdiffr snapshot; a gallery-vignette entry; `R CMD check --as-cran` clean (codoc + vignette OK). No new dependency.