### PR TITLE
Add cell.grid to box glyphs inside light cell rectangles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## New features
 
+- New argument `cell.grid` to draw a light rectangle around every cell (behind
+  the glyphs) and drop the through-center gridlines, so the sized glyphs
+  (`method = "circle"` or `scale.square = TRUE`) sit inside boxed cells -- the
+  corrplot boxed-cell look: `ggcorrplot(corr, method = "circle", cell.grid =
+  TRUE)`. The cell border color is set with the companion argument
+  `cell.grid.col` (default `"grey90"`). Defaults to `FALSE`; has no effect on a
+  full-tile square heatmap, whose tiles already carry an `outline.color` border.
+
 - New argument `scale.square` to size the squares by the absolute correlation
   when `method = "square"`: `ggcorrplot(corr, scale.square = TRUE)` scales each
   square (larger = stronger correlation) on top of the fill color, the classic

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -420,6 +420,9 @@ ggcorrplot <- function(corr,
       scale.square = scale.square,
       cell.grid = cell.grid, cell.grid.col = cell.grid.col
     )
+    # A mixed layout always boxes at least the diagonal (name) region when
+    # cell.grid = TRUE, so the gridline blanking below is always consistent here.
+    draw.cell.grid <- cell.grid
   } else {
     p <-
       ggplot2::ggplot(
@@ -434,7 +437,8 @@ ggcorrplot <- function(corr,
     # (outline.color), so a second border would double-draw. fill = NA overrides
     # the inherited aes(fill = value) for drawing while still training the same
     # fill scale as the glyph layer (byte-identical fill legend).
-    if (cell.grid && !(method == "square" && !scale.square)) {
+    draw.cell.grid <- cell.grid && !(method == "square" && !scale.square)
+    if (draw.cell.grid) {
       p <- p + ggplot2::geom_tile(fill = NA, colour = cell.grid.col)
     }
 
@@ -513,10 +517,12 @@ ggcorrplot <- function(corr,
       axis.text.y = ggplot2::element_text(size = tl.cex, colour = tl.col)
     )
   # cell.grid replaces the through-center gridlines with per-cell rectangles, so
-  # blank the panel grid (added after the theme() above so it wins). No visual
-  # change for a full-tile square heatmap (its gridlines already sit behind the
-  # opaque tiles), so this stays scoped to the opt-in.
-  if (cell.grid) {
+  # blank the panel grid (added after the theme() above so it wins). Gated on
+  # draw.cell.grid -- TRUE only when boxes were actually drawn -- so a full-tile
+  # square heatmap (which draws no box and keeps its gridlines behind the opaque
+  # tiles) is genuinely untouched, matching the documented "no effect". This also
+  # keeps a lower/upper full-tile square's gridlines in the blank triangle intact.
+  if (draw.cell.grid) {
     p <- p + ggplot2::theme(
       panel.grid.major = ggplot2::element_blank(),
       panel.grid.minor = ggplot2::element_blank()

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -14,6 +14,15 @@
 #'   (circles are always sized). Uses \code{circle.scale} to tune the size range.
 #'   As with \code{method = "circle"}, coefficient labels (\code{lab = TRUE}) are
 #'   drawn at full size and may overflow the smallest squares.
+#' @param cell.grid logical. If \code{TRUE}, draw a light rectangle around every
+#'   cell (behind the glyphs) and remove the through-center gridlines, so the
+#'   sized glyphs (\code{method = "circle"} or \code{scale.square = TRUE}) sit
+#'   inside boxed cells -- the corrplot boxed-cell look. Defaults to \code{FALSE}
+#'   (the current behavior). Has no effect on a full-tile square heatmap
+#'   (\code{method = "square"} without \code{scale.square}), whose tiles already
+#'   carry a cell border (\code{outline.color}).
+#' @param cell.grid.col the color of the \code{cell.grid} cell borders. Defaults
+#'   to \code{"grey90"}. Only used when \code{cell.grid = TRUE}.
 #' @param lower.method,upper.method character, an optional per-triangle glyph for
 #'   a mixed layout: one of "square", "circle" or "number" (the coefficient drawn
 #'   as text, colored by its value on the same scale as the fill, so coefficients
@@ -267,7 +276,9 @@ ggcorrplot <- function(corr,
                        palette = NULL,
                        preset = NULL,
                        hc.rect.col = "gray30",
-                       scale.square = FALSE) {
+                       scale.square = FALSE,
+                       cell.grid = FALSE,
+                       cell.grid.col = "grey90") {
   type <- match.arg(type)
   method <- match.arg(method)
   # Resolve on insig[1] (not match.arg(insig)) so a caller passing the old
@@ -406,7 +417,8 @@ ggcorrplot <- function(corr,
       outline.color = outline.color, circle.scale = circle.scale,
       lab_size = lab_size, tl.cex = tl.cex, tl.col = tl.col,
       digits = digits, nsmall = nsmall, leading.zero = leading.zero,
-      scale.square = scale.square
+      scale.square = scale.square,
+      cell.grid = cell.grid, cell.grid.col = cell.grid.col
     )
   } else {
     p <-
@@ -414,6 +426,17 @@ ggcorrplot <- function(corr,
         data = corr,
         mapping = ggplot2::aes(x = .data[["Var1"]], y = .data[["Var2"]], fill = .data[["value"]])
       )
+
+    # cell.grid: draw a light cell-rectangle grid BEHIND the sized glyphs so they
+    # sit inside boxed cells (the corrplot look). Added before the glyph layer so
+    # it renders underneath. Skipped for a full-tile square heatmap (method =
+    # "square" without scale.square): its geom_tile already carries a cell border
+    # (outline.color), so a second border would double-draw. fill = NA overrides
+    # the inherited aes(fill = value) for drawing while still training the same
+    # fill scale as the glyph layer (byte-identical fill legend).
+    if (cell.grid && !(method == "square" && !scale.square)) {
+      p <- p + ggplot2::geom_tile(fill = NA, colour = cell.grid.col)
+    }
 
     # modification based on method (extracted so the mixed-method path can request
     # a different glyph per triangle from the same builder, P0.0)
@@ -489,6 +512,16 @@ ggcorrplot <- function(corr,
       ),
       axis.text.y = ggplot2::element_text(size = tl.cex, colour = tl.col)
     )
+  # cell.grid replaces the through-center gridlines with per-cell rectangles, so
+  # blank the panel grid (added after the theme() above so it wins). No visual
+  # change for a full-tile square heatmap (its gridlines already sit behind the
+  # opaque tiles), so this stays scoped to the opt-in.
+  if (cell.grid) {
+    p <- p + ggplot2::theme(
+      panel.grid.major = ggplot2::element_blank(),
+      panel.grid.minor = ggplot2::element_blank()
+    )
+  }
   if (coord.fixed) {
     p <- p + ggplot2::coord_fixed()
   } else {
@@ -876,7 +909,8 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
 # variable name. Returns a list of ggplot components.
 .mixed_layers <- function(df, lower.method, upper.method,
                           outline.color, circle.scale, lab_size, tl.cex, tl.col,
-                          digits, nsmall, leading.zero, scale.square = FALSE) {
+                          digits, nsmall, leading.zero, scale.square = FALSE,
+                          cell.grid = FALSE, cell.grid.col = "grey90") {
   xi <- as.integer(df$Var1)
   yi <- as.integer(df$Var2)
   regions <- list(
@@ -891,6 +925,16 @@ cor_pmat <- function(x, ..., use = c("pairwise.complete.obs", "everything")) {
     d <- r$data
     if (nrow(d) == 0) next
     m <- r$method
+    # cell.grid: box every region behind its glyph, EXCEPT a full-tile square
+    # region (m == "square" without scale.square), whose geom_tile already draws
+    # an outline.color border -- a second box would double-draw. Added before the
+    # region's glyph so it renders underneath. fill = NA (no aes fill inherited
+    # from the mixed base plot) draws only the border.
+    if (cell.grid && !(m == "square" && !scale.square)) {
+      layers <- c(layers, list(ggplot2::geom_tile(
+        data = d, fill = NA, colour = cell.grid.col
+      )))
+    }
     if (m == "square" && !scale.square) {
       layers <- c(layers, list(ggplot2::geom_tile(
         data = d,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -6,6 +6,7 @@ erroring
 ggplot
 ggtheme
 glyphs
+gridlines
 hc
 hclust
 http

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -47,7 +47,9 @@ ggcorrplot(
   palette = NULL,
   preset = NULL,
   hc.rect.col = "gray30",
-  scale.square = FALSE
+  scale.square = FALSE,
+  cell.grid = FALSE,
+  cell.grid.col = "grey90"
 )
 
 cor_pmat(x, ..., use = c("pairwise.complete.obs", "everything"))
@@ -219,6 +221,17 @@ squares, the current behavior). Has no effect for \code{method = "circle"}
 (circles are always sized). Uses \code{circle.scale} to tune the size range.
 As with \code{method = "circle"}, coefficient labels (\code{lab = TRUE}) are
 drawn at full size and may overflow the smallest squares.}
+
+\item{cell.grid}{logical. If \code{TRUE}, draw a light rectangle around every
+cell (behind the glyphs) and remove the through-center gridlines, so the
+sized glyphs (\code{method = "circle"} or \code{scale.square = TRUE}) sit
+inside boxed cells -- the corrplot boxed-cell look. Defaults to \code{FALSE}
+(the current behavior). Has no effect on a full-tile square heatmap
+(\code{method = "square"} without \code{scale.square}), whose tiles already
+carry a cell border (\code{outline.color}).}
+
+\item{cell.grid.col}{the color of the \code{cell.grid} cell borders. Defaults
+to \code{"grey90"}. Only used when \code{cell.grid = TRUE}.}
 
 \item{x}{numeric matrix or data frame}
 

--- a/tests/testthat/_snaps/vdiffr/ggcorrplot-works-cell-grid-circle.svg
+++ b/tests/testthat/_snaps/vdiffr/ggcorrplot-works-cell-grid-circle.svg
@@ -1,0 +1,323 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw'>
+    <rect x='50.82' y='0.00' width='618.36' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTAuODJ8NjY5LjE4fDAuMDB8NTc2LjAw)'>
+<rect x='50.82' y='0.00' width='618.36' height='576.00' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg=='>
+    <rect x='86.59' y='22.78' width='517.27' height='517.27' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpODYuNTl8NjAzLjg2fDIyLjc4fDU0MC4wNg==)'>
+<rect x='91.21' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='489.25' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='443.07' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='396.88' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='350.70' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='304.51' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='258.33' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='212.14' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='165.96' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='119.77' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='73.59' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='91.21' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='137.39' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='183.58' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='229.76' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='275.95' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='322.13' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='368.32' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='414.50' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='460.69' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='506.87' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<rect x='553.06' y='27.40' width='46.19' height='46.19' style='stroke-width: 0.43; stroke: #E5E5E5; stroke-linecap: butt; stroke-linejoin: miter;' />
+<circle cx='114.30' cy='512.35' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='160.48' cy='512.35' r='10.66' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #502BFF;' />
+<circle cx='206.67' cy='512.35' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #7145FF;' />
+<circle cx='252.85' cy='512.35' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #7145FF;' />
+<circle cx='299.04' cy='512.35' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='345.22' cy='512.35' r='10.66' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #502BFF;' />
+<circle cx='391.41' cy='512.35' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='437.59' cy='512.35' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='483.78' cy='512.35' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF8969;' />
+<circle cx='529.96' cy='512.35' r='8.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF9E81;' />
+<circle cx='576.15' cy='512.35' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='114.30' cy='466.16' r='10.66' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #502BFF;' />
+<circle cx='160.48' cy='466.16' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='206.67' cy='466.16' r='10.66' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF3E22;' />
+<circle cx='252.85' cy='466.16' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='299.04' cy='466.16' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='345.22' cy='466.16' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='391.41' cy='466.16' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='437.59' cy='466.16' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #7145FF;' />
+<circle cx='483.78' cy='466.16' r='8.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #B38BFF;' />
+<circle cx='529.96' cy='466.16' r='8.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #B38BFF;' />
+<circle cx='576.15' cy='466.16' r='8.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF9E81;' />
+<circle cx='114.30' cy='419.98' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #7145FF;' />
+<circle cx='160.48' cy='419.98' r='10.66' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF3E22;' />
+<circle cx='206.67' cy='419.98' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='252.85' cy='419.98' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='299.04' cy='419.98' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='345.22' cy='419.98' r='10.66' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF3E22;' />
+<circle cx='391.41' cy='419.98' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #C4A2FF;' />
+<circle cx='437.59' cy='419.98' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='483.78' cy='419.98' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='529.96' cy='419.98' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='576.15' cy='419.98' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='114.30' cy='373.79' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #7145FF;' />
+<circle cx='160.48' cy='373.79' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='206.67' cy='373.79' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='252.85' cy='373.79' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='299.04' cy='373.79' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #C4A2FF;' />
+<circle cx='345.22' cy='373.79' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='391.41' cy='373.79' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='437.59' cy='373.79' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='483.78' cy='373.79' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='529.96' cy='373.79' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #F2E7FF;' />
+<circle cx='576.15' cy='373.79' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='114.30' cy='327.61' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='160.48' cy='327.61' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='206.67' cy='327.61' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='252.85' cy='327.61' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #C4A2FF;' />
+<circle cx='299.04' cy='327.61' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='345.22' cy='327.61' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='391.41' cy='327.61' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFECE5;' />
+<circle cx='437.59' cy='327.61' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='483.78' cy='327.61' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='529.96' cy='327.61' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='576.15' cy='327.61' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #F2E7FF;' />
+<circle cx='114.30' cy='281.42' r='10.66' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #502BFF;' />
+<circle cx='160.48' cy='281.42' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='206.67' cy='281.42' r='10.66' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF3E22;' />
+<circle cx='252.85' cy='281.42' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='299.04' cy='281.42' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='345.22' cy='281.42' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='391.41' cy='281.42' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='437.59' cy='281.42' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='483.78' cy='281.42' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='529.96' cy='281.42' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='576.15' cy='281.42' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='114.30' cy='235.24' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='160.48' cy='235.24' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='206.67' cy='235.24' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #C4A2FF;' />
+<circle cx='252.85' cy='235.24' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='299.04' cy='235.24' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFECE5;' />
+<circle cx='345.22' cy='235.24' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='391.41' cy='235.24' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='437.59' cy='235.24' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='483.78' cy='235.24' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='529.96' cy='235.24' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='576.15' cy='235.24' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='114.30' cy='189.05' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='160.48' cy='189.05' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #7145FF;' />
+<circle cx='206.67' cy='189.05' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='252.85' cy='189.05' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='299.04' cy='189.05' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='345.22' cy='189.05' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='391.41' cy='189.05' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='437.59' cy='189.05' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='483.78' cy='189.05' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFD9CB;' />
+<circle cx='529.96' cy='189.05' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFD9CB;' />
+<circle cx='576.15' cy='189.05' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='114.30' cy='142.86' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF8969;' />
+<circle cx='160.48' cy='142.86' r='8.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #B38BFF;' />
+<circle cx='206.67' cy='142.86' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='252.85' cy='142.86' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='299.04' cy='142.86' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='345.22' cy='142.86' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='391.41' cy='142.86' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='437.59' cy='142.86' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFD9CB;' />
+<circle cx='483.78' cy='142.86' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='529.96' cy='142.86' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='576.15' cy='142.86' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFECE5;' />
+<circle cx='114.30' cy='96.68' r='8.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF9E81;' />
+<circle cx='160.48' cy='96.68' r='8.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #B38BFF;' />
+<circle cx='206.67' cy='96.68' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='252.85' cy='96.68' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #F2E7FF;' />
+<circle cx='299.04' cy='96.68' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='345.22' cy='96.68' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='391.41' cy='96.68' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #E3D0FF;' />
+<circle cx='437.59' cy='96.68' r='6.76' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFD9CB;' />
+<circle cx='483.78' cy='96.68' r='10.27' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF5B3A;' />
+<circle cx='529.96' cy='96.68' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+<circle cx='576.15' cy='96.68' r='7.64' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFC6B2;' />
+<circle cx='114.30' cy='50.49' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='160.48' cy='50.49' r='8.89' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF9E81;' />
+<circle cx='206.67' cy='50.49' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='252.85' cy='50.49' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF7352;' />
+<circle cx='299.04' cy='50.49' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #F2E7FF;' />
+<circle cx='345.22' cy='50.49' r='8.32' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFB299;' />
+<circle cx='391.41' cy='50.49' r='9.85' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #8A5DFF;' />
+<circle cx='437.59' cy='50.49' r='9.39' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #A074FF;' />
+<circle cx='483.78' cy='50.49' r='4.62' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFECE5;' />
+<circle cx='529.96' cy='50.49' r='7.64' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FFC6B2;' />
+<circle cx='576.15' cy='50.49' r='11.02' style='stroke-width: 0.71; stroke: #BEBEBE; fill: #FF0000;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='81.66' y='516.47' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text x='81.66' y='470.29' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text x='81.66' y='424.10' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text x='81.66' y='377.92' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text x='81.66' y='331.73' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text x='81.66' y='285.55' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text x='81.66' y='239.36' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text x='81.66' y='193.18' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text x='81.66' y='146.99' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text x='81.66' y='100.81' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text x='81.66' y='54.62' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text transform='translate(120.14,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>mpg</text>
+<text transform='translate(166.32,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='14.67px' lengthAdjust='spacingAndGlyphs'>cyl</text>
+<text transform='translate(212.51,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>disp</text>
+<text transform='translate(258.69,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>hp</text>
+<text transform='translate(304.88,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='20.68px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<text transform='translate(351.06,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(397.25,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='25.36px' lengthAdjust='spacingAndGlyphs'>qsec</text>
+<text transform='translate(443.43,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='12.01px' lengthAdjust='spacingAndGlyphs'>vs</text>
+<text transform='translate(489.62,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='16.68px' lengthAdjust='spacingAndGlyphs'>am</text>
+<text transform='translate(535.80,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>gear</text>
+<text transform='translate(581.99,550.83) rotate(-45)' text-anchor='end' style='font-size: 12.00px; fill: #4D4D4D; font-family: sans;' textLength='23.35px' lengthAdjust='spacingAndGlyphs'>carb</text>
+<text x='620.30' y='239.27' style='font-size: 11.00px; font-family: sans;' textLength='21.39px' lengthAdjust='spacingAndGlyphs'>Corr</text>
+<image width='17.28' height='86.40' x='620.30' y='245.89' preserveAspectRatio='none' xlink:href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAEsCAYAAAACUNnVAAAAsUlEQVQ4jbWPwQ7DIAxDH2aTpv3/t05aW2CngWChTSvtYjmxYwMFingK8YiIewMhYkTchIgGyGLhOzaI/S60cTAHRNCvOlwE68Jix5b5bZ8Srlm8ve2DB+O0cn/se91tjo4zz/ifxfs+AioFVHKFMmEcW/ZTcBZ58y6e5WtRjrN8Ws3GS62ivBtlqr0wDciDz2nJRtEgmKOxS3WXhl1lFmypY2tlywZaEui9gV4rAKV8ANuwLHQSilYnAAAAAElFTkSuQmCC'/>
+<polyline points='634.12,332.14 637.58,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,310.61 637.58,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,289.09 637.58,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,267.56 637.58,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='634.12,246.03 637.58,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,332.14 620.30,332.14 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,310.61 620.30,310.61 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,289.09 620.30,289.09 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,267.56 620.30,267.56 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='623.76,246.03 620.30,246.03 ' style='stroke-width: 0.38; stroke: #FFFFFF; stroke-linecap: butt;' />
+<text x='643.06' y='335.17' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-1.0</text>
+<text x='643.06' y='313.64' style='font-size: 8.80px; font-family: sans;' textLength='15.16px' lengthAdjust='spacingAndGlyphs'>-0.5</text>
+<text x='643.06' y='292.11' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='643.06' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='643.06' y='249.06' style='font-size: 8.80px; font-family: sans;' textLength='12.23px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<text x='86.59' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='188.54px' lengthAdjust='spacingAndGlyphs'>ggcorrplot works - cell grid circle</text>
+</g>
+</svg>

--- a/tests/testthat/test-cell-grid.R
+++ b/tests/testthat/test-cell-grid.R
@@ -1,0 +1,98 @@
+# cell.grid: draw a light rectangle behind every (sized) cell -- the corrplot
+# boxed-cell look. Default FALSE keeps every existing call byte-identical.
+
+corr <- round(cor(mtcars), 1)
+geoms <- function(p) unname(vapply(p$layers, function(l) class(l$geom)[1], ""))
+first_layer_col <- function(p) p$layers[[1]]$aes_params$colour
+
+test_that("cell.grid defaults to FALSE: no cell-grid layer, output unchanged", {
+  # circle default has exactly one glyph layer (GeomPoint), no background tile
+  p <- ggcorrplot(corr, method = "circle")
+  expect_identical(geoms(p), "GeomPoint")
+  # explicit FALSE == implicit default (byte-identical built data)
+  expect_equal(
+    ggplot2::ggplot_build(ggcorrplot(corr, method = "circle"))$data,
+    ggplot2::ggplot_build(ggcorrplot(corr, method = "circle", cell.grid = FALSE))$data
+  )
+})
+
+test_that("cell.grid = TRUE boxes circles: a GeomTile is drawn BEFORE the glyph", {
+  p <- ggcorrplot(corr, method = "circle", cell.grid = TRUE)
+  g <- geoms(p)
+  # background tile first, glyph second
+  expect_identical(g[1], "GeomTile")
+  expect_identical(g[2], "GeomPoint")
+  # the background tile has no fill and uses the default cell.grid.col
+  expect_true(is.na(p$layers[[1]]$aes_params$fill))
+  expect_identical(first_layer_col(p), "grey90")
+})
+
+test_that("cell.grid = TRUE boxes size-scaled squares", {
+  p <- ggcorrplot(corr, scale.square = TRUE, cell.grid = TRUE)
+  g <- geoms(p)
+  expect_identical(g[1], "GeomTile")
+  expect_identical(g[2], "GeomPoint")
+  expect_identical(p$layers[[2]]$aes_params$shape, 22)
+})
+
+test_that("cell.grid.col sets the cell border color", {
+  p <- ggcorrplot(corr, method = "circle", cell.grid = TRUE, cell.grid.col = "black")
+  expect_identical(first_layer_col(p), "black")
+})
+
+test_that("cell.grid has no effect on a full-tile square heatmap", {
+  # method = "square" without scale.square already draws a bordered tile, so no
+  # extra background tile is added and the built data is unchanged
+  a <- ggcorrplot(corr, method = "square")
+  b <- ggcorrplot(corr, method = "square", cell.grid = TRUE)
+  expect_identical(geoms(a), "GeomTile")
+  expect_identical(geoms(b), "GeomTile") # still a single tile layer
+  expect_equal(
+    ggplot2::ggplot_build(a)$data,
+    ggplot2::ggplot_build(b)$data
+  )
+})
+
+test_that("cell.grid = TRUE blanks the panel gridlines", {
+  off <- ggcorrplot(corr, method = "circle")
+  on <- ggcorrplot(corr, method = "circle", cell.grid = TRUE)
+  # default keeps the theme's gridlines; cell.grid removes them
+  expect_false(inherits(off$theme$panel.grid.major, "element_blank"))
+  expect_true(inherits(on$theme$panel.grid.major, "element_blank"))
+  expect_true(inherits(on$theme$panel.grid.minor, "element_blank"))
+})
+
+test_that("cell.grid boxes every region of a mixed layout except full-tile squares", {
+  # circle, number and diagonal-name regions each get a background box tile
+  p <- ggcorrplot(corr,
+    lower.method = "number", upper.method = "circle", cell.grid = TRUE,
+    show.legend = FALSE
+  )
+  g <- geoms(p)
+  tile_idx <- which(g == "GeomTile")
+  # one box per non-empty region (lower number, upper circle, diagonal name)
+  expect_identical(length(tile_idx), 3L)
+  # every box carries the cell.grid color and maps no fill (transparent box)
+  cols <- vapply(tile_idx, function(i) p$layers[[i]]$aes_params$colour, "")
+  expect_true(all(cols == "grey90"))
+  has_fill_map <- vapply(tile_idx, function(i) "fill" %in% names(p$layers[[i]]$mapping), TRUE)
+  expect_false(any(has_fill_map))
+})
+
+test_that("a full-tile square region in a mixed layout is not double-boxed", {
+  # lower = square (full tile, has its own outline.color border) -> no extra
+  # cell.grid tile for that region; upper = circle -> boxed
+  p <- ggcorrplot(corr,
+    lower.method = "square", upper.method = "circle", cell.grid = TRUE,
+    show.legend = FALSE
+  )
+  g <- geoms(p)
+  # GeomTile layers = the full-tile square region (1) + the circle region's box
+  # (1) + the diagonal name box (1) = fewer than if every region were boxed.
+  # Assert the full-tile square region's tile is the bordered heatmap tile, not a
+  # transparent cell.grid box: it maps fill and uses outline.color.
+  square_tiles <- Filter(function(l) {
+    class(l$geom)[1] == "GeomTile" && "fill" %in% names(l$mapping)
+  }, p$layers)
+  expect_true(length(square_tiles) >= 1)
+})

--- a/tests/testthat/test-cell-grid.R
+++ b/tests/testthat/test-cell-grid.R
@@ -51,6 +51,12 @@ test_that("cell.grid has no effect on a full-tile square heatmap", {
     ggplot2::ggplot_build(a)$data,
     ggplot2::ggplot_build(b)$data
   )
+  # "no effect" must include the theme: the gridlines are NOT blanked for a
+  # full-tile square heatmap (no box was drawn to replace them). Checked on a
+  # lower triangle, where those gridlines are actually visible in the blank half.
+  low <- ggcorrplot(corr, method = "square", type = "lower", cell.grid = TRUE)
+  expect_false(inherits(b$theme$panel.grid.major, "element_blank"))
+  expect_false(inherits(low$theme$panel.grid.major, "element_blank"))
 })
 
 test_that("cell.grid = TRUE blanks the panel gridlines", {

--- a/tests/testthat/test-vdiffr.R
+++ b/tests/testthat/test-vdiffr.R
@@ -78,5 +78,11 @@ if (getRversion() >= "4.1") {
       title = "ggcorrplot works - scale square",
       fig = ggcorrplot(corr, scale.square = TRUE, outline.color = "white")
     )
+
+    set.seed(123)
+    vdiffr::expect_doppelganger(
+      title = "ggcorrplot works - cell grid circle",
+      fig = ggcorrplot(corr, method = "circle", cell.grid = TRUE)
+    )
   })
 }


### PR DESCRIPTION
## What

New argument `cell.grid` (default `FALSE`) draws a light rectangle around every cell, behind the glyphs, and drops the through-center gridlines. Sized glyphs (`method = "circle"` or `scale.square = TRUE`) then sit inside boxed cells instead of floating on the center gridlines. The border color is set with the companion `cell.grid.col` (default `"grey90"`).

```r
ggcorrplot(corr, method = "circle", cell.grid = TRUE)
ggcorrplot(corr, scale.square = TRUE, cell.grid = TRUE, outline.color = "white")
```

Has no effect on a full-tile square heatmap (`method = "square"` without `scale.square`), whose tiles already carry an `outline.color` border, so no second box is drawn and its gridlines are left intact. In a mixed layout every region is boxed except full-tile square regions.

## Non-regression

- Both arguments default to the current behavior; every pre-existing call produces identical output.
- Appended at the end of the signature (positional binding intact); no existing argument name is a prefix of `cell.grid`/`cell.grid.col`.

## Tests

- `tests/testthat/test-cell-grid.R`: layer order (background tile before the glyph), no tile and unchanged theme for full-tile squares, `cell.grid.col` honored, gridlines blanked only when boxes are drawn, mixed-layout boxing, and the default (`cell.grid = FALSE`) producing identical output.
- One vdiffr snapshot (`cell grid circle`).
- `R CMD check --as-cran`: 0 errors / 0 warnings / 1 NOTE (dev-version incoming-feasibility only).