### PR TITLE
Add a pkgdown build helper that drops internal-markdown pages

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,7 @@
 ^cran-comments\.md$
 ^revdep$
 ^docs$
+^tools$
 ^_pkgdown\.yml$
 tests\^spelling
 ^\.github$

--- a/tools/build-site.R
+++ b/tools/build-site.R
@@ -1,0 +1,29 @@
+#!/usr/bin/env Rscript
+# Build the pkgdown site, then drop pages pkgdown generated from INTERNAL
+# root markdown files.
+#
+# Why this wrapper exists: pkgdown renders every root-level `*.md` into a page
+# (everything except README/LICENSE/NEWS and a few hardcoded templates) and it
+# does NOT consult `.Rbuildignore`. So `CLAUDE.md` -- the internal project
+# instructions -- would otherwise be published as `docs/CLAUDE.html`. pkgdown
+# offers no option to exclude a root `.md`, so we post-process: any root `*.md`
+# that is `.Rbuildignore`d is treated as internal and its built page removed.
+# Run this (from the package root) instead of a bare `pkgdown::build_site()`:
+#   Rscript tools/build-site.R
+
+pkgdown::build_site(preview = FALSE)
+
+root_md <- list.files(".", pattern = "\\.md$")
+ignore <- readLines(".Rbuildignore", warn = FALSE)
+ignore <- ignore[nzchar(ignore)]
+is_internal <- function(f) any(vapply(ignore, function(p) grepl(p, f, perl = TRUE), logical(1)))
+internal_md <- Filter(is_internal, root_md)
+
+html <- file.path("docs", sub("\\.md$", ".html", internal_md))
+drop <- html[file.exists(html)]
+if (length(drop)) {
+  unlink(drop)
+  message("Removed internal pkgdown page(s): ", paste(basename(drop), collapse = ", "))
+} else {
+  message("No internal pkgdown pages to remove.")
+}


### PR DESCRIPTION
## Problem

pkgdown renders **every** root-level `*.md` into a site page (all except README/LICENSE/NEWS and a couple of hardcoded templates) and it does **not** consult `.Rbuildignore`. So a bare `pkgdown::build_site()` publishes the internal `CLAUDE.md` as `docs/CLAUDE.html`. pkgdown provides no option to exclude a root `.md`.

## Fix

`tools/build-site.R` is the canonical pkgdown build: it runs `build_site()` and then removes any page generated from an `.Rbuildignore`d root `.md` (currently `CLAUDE.md`). Fully general — it derives the internal set from `.Rbuildignore`, so any future internal `.md` (e.g. `TODO.md`) is handled automatically. `tools/` is added to `.Rbuildignore` so the helper never ships in the package tarball.

Verified: after `Rscript tools/build-site.R`, `docs/CLAUDE.html` is gone and the real pages (home, reference, both articles, news) remain; `R CMD build` excludes `tools/`.