### PR TITLE
Keep the paired README plots side by side on the pkgdown site

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -79,7 +79,7 @@ p.mat[1:4, 1:4]
 The default draws each correlation as a colored square; `method = "circle"`
 encodes the value with the circle area instead.
 
-```{r basic, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%"}
+```{r basic, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%", fig.align = "default"}
 ggcorrplot(corr)
 ggcorrplot(corr, method = "circle")
 ```
@@ -90,7 +90,7 @@ ggcorrplot(corr, method = "circle")
 correlations dominate; `cell.grid = TRUE` draws a light box around every cell so
 the glyphs sit inside a grid instead of floating on the axis lines.
 
-```{r boxed, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%"}
+```{r boxed, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%", fig.align = "default"}
 ggcorrplot(corr, scale.square = TRUE, cell.grid = TRUE, outline.color = "white")
 ggcorrplot(corr, method = "circle", cell.grid = TRUE)
 ```
@@ -101,7 +101,7 @@ ggcorrplot(corr, method = "circle", cell.grid = TRUE)
 correlated variables sit together. `hc.rect` then draws rectangles around the
 clusters obtained by cutting the tree.
 
-```{r cluster, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%"}
+```{r cluster, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%", fig.align = "default"}
 ggcorrplot(corr, hc.order = TRUE, outline.color = "white")
 ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, outline.color = "white")
 ```
@@ -110,7 +110,7 @@ ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, outline.color = "white")
 
 For a symmetric matrix the two triangles are redundant, so you can keep just one.
 
-```{r triangle, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%"}
+```{r triangle, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%", fig.align = "default"}
 ggcorrplot(corr, hc.order = TRUE, type = "lower", outline.color = "white")
 ggcorrplot(corr, hc.order = TRUE, type = "upper", outline.color = "white")
 ```
@@ -141,7 +141,7 @@ Passing `p.mat` marks the cells whose correlation is not significant at
 `sig.level` (default 0.05). By default a cross is drawn over them (`insig =
 "pch"`); `insig = "blank"` hides them instead.
 
-```{r insig, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%"}
+```{r insig, fig.width = 5.2, fig.height = 5, fig.show = "hold", out.width = "49%", fig.align = "default"}
 # Cross out the non-significant coefficients
 ggcorrplot(corr, hc.order = TRUE, type = "lower", p.mat = p.mat)
 # Leave them blank

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ ggcorrplot(corr)
 ggcorrplot(corr, method = "circle")
 ```
 
-<img src="man/figures/README-basic-1.png" alt="" width="49%" style="display: block; margin: auto;" /><img src="man/figures/README-basic-2.png" alt="" width="49%" style="display: block; margin: auto;" />
+<img src="man/figures/README-basic-1.png" alt="" width="49%" /><img src="man/figures/README-basic-2.png" alt="" width="49%" />
 
 ### Sized glyphs in boxed cells
 
@@ -99,7 +99,7 @@ ggcorrplot(corr, scale.square = TRUE, cell.grid = TRUE, outline.color = "white")
 ggcorrplot(corr, method = "circle", cell.grid = TRUE)
 ```
 
-<img src="man/figures/README-boxed-1.png" alt="" width="49%" style="display: block; margin: auto;" /><img src="man/figures/README-boxed-2.png" alt="" width="49%" style="display: block; margin: auto;" />
+<img src="man/figures/README-boxed-1.png" alt="" width="49%" /><img src="man/figures/README-boxed-2.png" alt="" width="49%" />
 
 ### Reorder by clustering, and outline the clusters
 
@@ -112,7 +112,7 @@ ggcorrplot(corr, hc.order = TRUE, outline.color = "white")
 ggcorrplot(corr, hc.order = TRUE, hc.rect = 3, outline.color = "white")
 ```
 
-<img src="man/figures/README-cluster-1.png" alt="" width="49%" style="display: block; margin: auto;" /><img src="man/figures/README-cluster-2.png" alt="" width="49%" style="display: block; margin: auto;" />
+<img src="man/figures/README-cluster-1.png" alt="" width="49%" /><img src="man/figures/README-cluster-2.png" alt="" width="49%" />
 
 ### Lower / upper triangle
 
@@ -124,7 +124,7 @@ ggcorrplot(corr, hc.order = TRUE, type = "lower", outline.color = "white")
 ggcorrplot(corr, hc.order = TRUE, type = "upper", outline.color = "white")
 ```
 
-<img src="man/figures/README-triangle-1.png" alt="" width="49%" style="display: block; margin: auto;" /><img src="man/figures/README-triangle-2.png" alt="" width="49%" style="display: block; margin: auto;" />
+<img src="man/figures/README-triangle-1.png" alt="" width="49%" /><img src="man/figures/README-triangle-2.png" alt="" width="49%" />
 
 ### Mixed layout
 
@@ -163,7 +163,7 @@ ggcorrplot(corr, hc.order = TRUE, type = "lower", p.mat = p.mat)
 ggcorrplot(corr, hc.order = TRUE, type = "lower", p.mat = p.mat, insig = "blank")
 ```
 
-<img src="man/figures/README-insig-1.png" alt="" width="49%" style="display: block; margin: auto;" /><img src="man/figures/README-insig-2.png" alt="" width="49%" style="display: block; margin: auto;" />
+<img src="man/figures/README-insig-1.png" alt="" width="49%" /><img src="man/figures/README-insig-2.png" alt="" width="49%" />
 
 ### Significance map
 


### PR DESCRIPTION
The README paired-plot chunks (fig.show = hold, out.width = 49%) inherited the global fig.align = center, so knitr tagged each image with style display: block; margin: auto. GitHub strips inline styles, so on GitHub the images stay inline and sit side by side; the pkgdown site keeps the style and stacks them vertically.

Setting fig.align = default on those five chunks (basic, boxed, cluster, triangle, insig) drops the display: block, so the paired plots render side by side in both renderers. Single-figure chunks are untouched and stay centered. Only the style attribute changes in README.md; the figures themselves are unchanged.