### PR TITLE
Refresh the release-hygiene files for the next version

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,31 +1,46 @@
 ## Submission
 
-This is a feature and bug-fix update (0.2.0), following the current CRAN version
-0.1.4.1. It adds several new, backward-compatible arguments to `ggcorrplot()`
-(`sig.stars`, `circle.scale`, `nsmall`, `legend.limit`, `coord.fixed`,
-`lab_fontface`, `leading.zero`, `tl.vjust`/`tl.hjust`), lets `colors` accept a
-palette of any length, adds a `use` argument to `cor_pmat()`, and fixes a number
-of defects (see NEWS.md). Default output for existing inputs is unchanged.
+This is a feature and bug-fix update (0.3.0), following the current CRAN version
+0.2.0. It adds backward-compatible arguments to `ggcorrplot()` for a mixed
+per-triangle layout (`lower.method`/`upper.method`), cluster rectangles
+(`hc.rect`, `hc.rect.col`), built-in colorblind-safe palettes (`palette`), a
+one-token publication preset (`preset`), size-scaled squares (`scale.square`) and
+boxed cells (`cell.grid`, `cell.grid.col`), plus a new `insig = "stars"` value for
+a standalone significance map. Two vignettes are added.
+
+`Imports` gains `grDevices` (a base R package, used for `col2rgb()`/`rgb()`).
+
+Two changes are intentional and alter output for a small set of inputs; both are
+called out in NEWS.md:
+
+* The plot axis is now always drawn in matrix (row/column) order. This fixes
+  `hc.order = TRUE` being silently ignored for matrices with numeric-looking
+  variable names; as a consequence `as.is` no longer affects the plot and is kept
+  only for backward compatibility.
+* `show.diag = FALSE` on a non-square matrix now removes only the genuine
+  self-pairs rather than the positional diagonal.
+
+Every other pre-existing argument combination produces byte-identical output to
+0.2.0.
 
 ## Test environments
 * local macOS, R 4.5.x
 * GitHub Actions: macOS-release, Windows-release, Ubuntu-{devel, release, oldrel-1}
-* win-builder release (R 4.x): OK
-* win-builder devel (R-devel): OK
+* win-builder release (R 4.x): TO RUN BEFORE SUBMISSION
+* win-builder devel (R-devel): TO RUN BEFORE SUBMISSION
 
 ## R CMD check results
-Local `R CMD check --as-cran`: 0 errors | 0 warnings | 0 notes.
+Local `R CMD check --as-cran`: 0 errors | 0 warnings | 2 notes.
 
-The only local note is "unable to verify current time" (the check host cannot
-reach a time server); it is environmental and does not appear on CI.
+Both notes are environmental and are expected to clear on the submitted tarball:
+
+* "Version contains large components" — the development version number
+  (0.2.0.9000). This clears once the version is set to 0.3.0 for submission.
+* "unable to verify current time" — the check host cannot reach a time server; it
+  does not appear on CI.
 
 ## Reverse dependencies
-Checked all 22 reverse dependencies with a source-level scan scoped to the
-behavior-changing surface of this release (the `hc.order` clustering/significance
-fixes, `tl.col` now being applied, and `cor_pmat()` returning `NA` instead of
-erroring for uncomputable pairs). No reverse dependency pins `ggcorrplot()` or
-`cor_pmat()` output in a test, snapshot, or `expect_error()`, and every caller
-supplies a square correlation matrix and default-compatible arguments, so no new
-problems are introduced. All other changes are additive: new behavior is behind
-new arguments whose defaults reproduce the current behavior, and default output
-for existing inputs is unchanged.
+TO RUN BEFORE SUBMISSION. The behavior-changing surface to scope the check to is
+the two intentional changes listed above (matrix-order axis / inert `as.is`, and
+non-square `show.diag = FALSE`); everything else in this release is additive,
+behind new arguments whose defaults reproduce the 0.2.0 behavior.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,6 +1,8 @@
 bw
 cex
 correlogram
+corrplot
+edgeless
 english
 erroring
 ggplot
@@ -14,10 +16,13 @@ insig
 misalign
 mitchelfruin
 mtcars
+omics
 pch
 pmat
+RdBu
 rstatix
 sig
 sthda
+theming
 unrounded
 www


### PR DESCRIPTION
Two release-hygiene files, both left over from the 0.2.0 cycle. No package code changes.

## `inst/WORDLIST`

Five domain terms the current documentation uses were missing, so every
`spelling::spell_check_package()` run reported them: `corrplot`, `edgeless`, `omics`, `RdBu`,
`theming`. `tests/spelling.R` runs with `error = FALSE` and `skip_on_cran`, so this was never a
failure — just noise on every check that had to be re-triaged each time. The list is clean now.

## `cran-comments.md`

It still described the 0.2.0 submission: that release's argument list, its reverse-dependency scan,
and an "0 errors | 0 warnings | 0 notes" line that the very next paragraph contradicted by
describing a note.

Rewritten for the coming release:

- what it adds (the mixed layout, cluster rectangles, palettes, preset, sized squares, boxed cells,
  the standalone significance map, two vignettes) and that `Imports` gains `grDevices`;
- the two intentional behaviour changes, each already called out in NEWS — the matrix-order axis
  with `as.is` now inert, and non-square `show.diag = FALSE` removing only genuine self-pairs —
  plus the statement that every other pre-existing argument combination is byte-identical to 0.2.0;
- the two notes the current check actually reports, and why each is environmental: the development
  version number, which clears on the version bump, and the unreachable time server;
- explicit `TO RUN BEFORE SUBMISSION` markers on the win-builder runs and the reverse-dependency
  check. Both are submission-time steps and neither has been run for this release, so the file says
  so rather than carrying over the previous release's results.

The file is `.Rbuildignore`d and does not ship in the tarball (confirmed).

## Checks

`R CMD check --as-cran`: 0 errors, 0 warnings, 2 notes — the development version number and the
unverifiable local clock, both as described above. `spelling::spell_check_package()` reports nothing.
