### PR TITLE
Link the docs to the correlation tutorials and set the version to 0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: ggcorrplot
 Title: Visualization of a Correlation Matrix using 'ggplot2'
-Version: 0.2.0.9000
-Date: 2026-07-08
+Version: 0.3.0
+Date: 2026-07-24
 Authors@R: 
     c(person(given = "Alboukadel",
              family = "Kassambara",

--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,14 @@
   `as.is = TRUE`, which previously produced an alphabetically-ordered axis, now
   follows the matrix order like every other call. Reported by @cabaez (#37).
 
+- `show.diag = FALSE` on a non-square matrix no longer blanks the wrong cells.
+  The diagonal has no positional meaning for an m x n matrix, yet the removal
+  wiped `min(m, n)` cells along the leading diagonal; it now removes only the
+  genuine self-pairs (a row and column naming the same variable), leaving a
+  matrix with disjoint row and column variables untouched. Square matrices, and
+  non-square matrices without dimnames, are unaffected. Follows up the non-square
+  support requested by @mt1022 (#5) and @qalid7 (#10).
+
 ## Minor changes
 
 - Added an introductory vignette, `vignette("ggcorrplot")`, walking through the
@@ -80,16 +88,6 @@
 
 - The help page and the README now link to the Datanovia correlation tutorials
   for worked examples of the plot and of the p-value matrix.
-
-## Bug fixes
-
-- `show.diag = FALSE` on a non-square matrix no longer blanks the wrong cells.
-  The diagonal has no positional meaning for an m x n matrix, yet the removal
-  wiped `min(m, n)` cells along the leading diagonal; it now removes only the
-  genuine self-pairs (a row and column naming the same variable), leaving a
-  matrix with disjoint row and column variables untouched. Square matrices, and
-  non-square matrices without dimnames, are unaffected. Follows up the non-square
-  support requested by @mt1022 (#5) and @qalid7 (#10).
 
 # ggcorrplot 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ggcorrplot 0.2.0.9000
+# ggcorrplot 0.3.0
 
 ## New features
 
@@ -77,6 +77,9 @@
   construction are now factored into internal helpers, with no change to the
   output of any existing call. This is groundwork for forthcoming per-triangle
   layout options.
+
+- The help page and the README now link to the Datanovia correlation tutorials
+  for worked examples of the plot and of the p-value matrix.
 
 ## Bug fixes
 

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -2,8 +2,13 @@
 #' @import ggplot2
 #' @importFrom grDevices col2rgb rgb
 #' @description \itemize{ \item ggcorrplot(): A graphical display of a
-#'   correlation matrix using ggplot2. \item cor_pmat(): Compute a correlation
-#'   matrix p-values. }
+#'   correlation matrix using ggplot2. The plot options are walked through in
+#'   \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
+#'   Correlation Matrix Heatmap in R with ggplot2}. \item cor_pmat(): Compute a
+#'   correlation matrix p-values. Its use alongside the correlation matrix
+#'   itself is covered in
+#'   \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation
+#'   Matrix in R: Compute, Visualize & P-values}. }
 #' @param corr the correlation matrix to visualize
 #' @param method character, the visualization method of correlation matrix to be
 #'   used. Allowed values are "square" (default), "circle".
@@ -247,6 +252,12 @@
 #'   lab = TRUE,
 #'   digits = 3
 #' )
+#' @seealso
+#'   \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
+#'   Correlation Matrix Heatmap in R with ggplot2} and
+#'   \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation
+#'   Matrix in R: Compute, Visualize & P-values} for worked examples of the
+#'   plot.
 #' @name ggcorrplot
 #' @rdname ggcorrplot
 #' @export
@@ -713,6 +724,9 @@ ggcorrplot <- function(corr,
 #'   \code{"everything"} (set a pair to \code{NA} as soon as either variable has
 #'   a missing value, matching \code{\link[stats]{cor}}'s default). Mirrors the
 #'   corresponding values of \code{\link[stats]{cor}}'s \code{use} argument.
+#' @seealso
+#'   \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r}{Correlation
+#'   Test in R: Pearson, Spearman & Kendall} for the test behind the p-values.
 #' @rdname ggcorrplot
 #' @export
 

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -5,10 +5,10 @@
 #'   correlation matrix using ggplot2. The plot options are walked through in
 #'   \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
 #'   Correlation Matrix Heatmap in R with ggplot2}. \item cor_pmat(): Compute a
-#'   correlation matrix p-values. Its use alongside the correlation matrix
-#'   itself is covered in
-#'   \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation
-#'   Matrix in R: Compute, Visualize & P-values}. }
+#'   correlation matrix p-values, to mark the significant cells. A worked
+#'   example is in
+#'   \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
+#'   Correlation Matrix Heatmap in R with ggplot2}. }
 #' @param corr the correlation matrix to visualize
 #' @param method character, the visualization method of correlation matrix to be
 #'   used. Allowed values are "square" (default), "circle".
@@ -254,10 +254,11 @@
 #' )
 #' @seealso
 #'   \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
-#'   Correlation Matrix Heatmap in R with ggplot2} and
+#'   Correlation Matrix Heatmap in R with ggplot2} for worked examples of the
+#'   plot, and
 #'   \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation
-#'   Matrix in R: Compute, Visualize & P-values} for worked examples of the
-#'   plot.
+#'   Matrix in R: Compute, Visualize & P-values} for computing the matrix and
+#'   its p-values beforehand.
 #' @name ggcorrplot
 #' @rdname ggcorrplot
 #' @export

--- a/R/ggcorrplot.R
+++ b/R/ggcorrplot.R
@@ -2,7 +2,7 @@
 #' @import ggplot2
 #' @importFrom grDevices col2rgb rgb
 #' @description \itemize{ \item ggcorrplot(): A graphical display of a
-#'   correlation matrix using ggplot2. The plot options are walked through in
+#'   correlation matrix using ggplot2. The main plot options are walked through in
 #'   \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
 #'   Correlation Matrix Heatmap in R with ggplot2}. \item cor_pmat(): Compute a
 #'   correlation matrix p-values, to mark the significant cells. A worked

--- a/README.Rmd
+++ b/README.Rmd
@@ -36,7 +36,8 @@ It can:
   significant** cells (including a standalone **significance map**), and
 - compute the matrix of **correlation p-values** with `cor_pmat()`.
 
-Learn more at <https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r>.
+Learn more in [ggcorrplot: Correlation Matrix Heatmap in R with
+ggplot2](https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r).
 
 ## Installation
 
@@ -163,7 +164,11 @@ ggcorrplot(corr, p.mat = p.mat, insig = "stars")
 ## Colors and theme
 
 `ggcorrplot()` returns a ggplot object, so any ggplot2 theme applies. `colors`
-sets the low / mid / high gradient.
+sets the low / mid / high gradient. For the ggplot2 side of this, see [ggplot2
+Colours in R: Change Colours by
+Group](https://www.datanovia.com/learn/data-visualization/ggplot2/colors) and
+[ggplot2 Themes in R: Customize the
+Look](https://www.datanovia.com/learn/data-visualization/ggplot2/themes).
 
 ```{r colors, fig.width = 5.6, fig.height = 5.4}
 ggcorrplot(corr,
@@ -172,3 +177,12 @@ ggcorrplot(corr,
   colors = c("#6D9EC1", "white", "#E46726")
 )
 ```
+
+## Related tutorials
+
+- [ggcorrplot: Correlation Matrix Heatmap in R with
+  ggplot2](https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r)
+- [Correlation Matrix in R: Compute, Visualize &
+  P-values](https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r)
+- [Correlogram in R: Visualize a Correlation Matrix with
+  corrplot](https://www.datanovia.com/learn/biostatistics/correlation/correlogram-in-r)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ It can:
     **significance map**), and
   - compute the matrix of **correlation p-values** with `cor_pmat()`.
 
-Learn more at
-<https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r>.
+Learn more in [ggcorrplot: Correlation Matrix Heatmap in R with
+ggplot2](https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r).
 
 ## Installation
 
@@ -183,7 +183,11 @@ ggcorrplot(corr, p.mat = p.mat, insig = "stars")
 ## Colors and theme
 
 `ggcorrplot()` returns a ggplot object, so any ggplot2 theme applies.
-`colors` sets the low / mid / high gradient.
+`colors` sets the low / mid / high gradient. For the ggplot2 side of
+this, see [ggplot2 Colours in R: Change Colours by
+Group](https://www.datanovia.com/learn/data-visualization/ggplot2/colors)
+and [ggplot2 Themes in R: Customize the
+Look](https://www.datanovia.com/learn/data-visualization/ggplot2/themes).
 
 ``` r
 ggcorrplot(corr,
@@ -194,3 +198,12 @@ ggcorrplot(corr,
 ```
 
 <img src="man/figures/README-colors-1.png" alt="" width="70%" style="display: block; margin: auto;" />
+
+## Related tutorials
+
+  - [ggcorrplot: Correlation Matrix Heatmap in R with
+    ggplot2](https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r)
+  - [Correlation Matrix in R: Compute, Visualize &
+    P-values](https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r)
+  - [Correlogram in R: Visualize a Correlation Matrix with
+    corrplot](https://www.datanovia.com/learn/biostatistics/correlation/correlogram-in-r)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -23,6 +23,12 @@ called out in NEWS.md:
 Every other pre-existing argument combination produces byte-identical output to
 0.2.0.
 
+This follows 0.2.0 closer than usual because the two changes above correct cases
+where the plot was silently wrong rather than erroring: `hc.order = TRUE` was
+ignored for matrices with numeric-looking variable names, and `show.diag = FALSE`
+blanked the wrong cells of a non-square matrix. I am happy to hold the release if
+you would prefer the usual interval.
+
 ## Test environments
 * local macOS, R 4.5.x
 * GitHub Actions: macOS-release, Windows-release, Ubuntu-{devel, release, oldrel-1}

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -30,12 +30,11 @@ Every other pre-existing argument combination produces byte-identical output to
 * win-builder devel (R-devel): TO RUN BEFORE SUBMISSION
 
 ## R CMD check results
-Local `R CMD check --as-cran`: 0 errors | 0 warnings | 2 notes.
+Local `R CMD check --as-cran` on the 0.3.0 tarball: 0 errors | 0 warnings |
+1 note. The same holds with `_R_CHECK_DEPENDS_ONLY_=true`.
 
-Both notes are environmental and are expected to clear on the submitted tarball:
+The note is environmental:
 
-* "Version contains large components" — the development version number
-  (0.2.0.9000). This clears once the version is set to 0.3.0 for submission.
 * "unable to verify current time" — the check host cannot reach a time server; it
   does not appear on CI.
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,7 +1,9 @@
 bw
 cex
+Colours
 correlogram
 corrplot
+Datanovia
 edgeless
 english
 erroring
@@ -20,9 +22,9 @@ omics
 pch
 pmat
 RdBu
+README
 rstatix
 sig
-sthda
 theming
 unrounded
 www

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -266,7 +266,7 @@ Returns a matrix containing the p-values of correlations }
 }
 \description{
 \itemize{ \item ggcorrplot(): A graphical display of a
-  correlation matrix using ggplot2. The plot options are walked through in
+  correlation matrix using ggplot2. The main plot options are walked through in
   \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
   Correlation Matrix Heatmap in R with ggplot2}. \item cor_pmat(): Compute a
   correlation matrix p-values, to mark the significant cells. A worked

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -266,8 +266,13 @@ Returns a matrix containing the p-values of correlations }
 }
 \description{
 \itemize{ \item ggcorrplot(): A graphical display of a
-  correlation matrix using ggplot2. \item cor_pmat(): Compute a correlation
-  matrix p-values. }
+  correlation matrix using ggplot2. The plot options are walked through in
+  \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
+  Correlation Matrix Heatmap in R with ggplot2}. \item cor_pmat(): Compute a
+  correlation matrix p-values. Its use alongside the correlation matrix
+  itself is covered in
+  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation
+  Matrix in R: Compute, Visualize & P-values}. }
 }
 \details{
 \code{cor_pmat()} tests each pair of columns with
@@ -370,4 +375,14 @@ ggcorrplot(cor(mtcars),
   lab = TRUE,
   digits = 3
 )
+}
+\seealso{
+\href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
+  Correlation Matrix Heatmap in R with ggplot2} and
+  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation
+  Matrix in R: Compute, Visualize & P-values} for worked examples of the
+  plot.
+
+\href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r}{Correlation
+  Test in R: Pearson, Spearman & Kendall} for the test behind the p-values.
 }

--- a/man/ggcorrplot.Rd
+++ b/man/ggcorrplot.Rd
@@ -269,10 +269,10 @@ Returns a matrix containing the p-values of correlations }
   correlation matrix using ggplot2. The plot options are walked through in
   \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
   Correlation Matrix Heatmap in R with ggplot2}. \item cor_pmat(): Compute a
-  correlation matrix p-values. Its use alongside the correlation matrix
-  itself is covered in
-  \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation
-  Matrix in R: Compute, Visualize & P-values}. }
+  correlation matrix p-values, to mark the significant cells. A worked
+  example is in
+  \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
+  Correlation Matrix Heatmap in R with ggplot2}. }
 }
 \details{
 \code{cor_pmat()} tests each pair of columns with
@@ -378,10 +378,11 @@ ggcorrplot(cor(mtcars),
 }
 \seealso{
 \href{https://www.datanovia.com/learn/biostatistics/correlation/ggcorrplot-in-r}{ggcorrplot:
-  Correlation Matrix Heatmap in R with ggplot2} and
+  Correlation Matrix Heatmap in R with ggplot2} for worked examples of the
+  plot, and
   \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-matrix-in-r}{Correlation
-  Matrix in R: Compute, Visualize & P-values} for worked examples of the
-  plot.
+  Matrix in R: Compute, Visualize & P-values} for computing the matrix and
+  its p-values beforehand.
 
 \href{https://www.datanovia.com/learn/biostatistics/correlation/correlation-test-in-r}{Correlation
   Test in R: Pearson, Spearman & Kendall} for the test behind the p-values.


### PR DESCRIPTION
Documentation and release metadata only. The diff in `R/` is comment lines, so no call changes behavior.

## Tutorial links

- `ggcorrplot()`: the ggcorrplot lesson in the description, and in See Also with the correlation-matrix lesson.
- `cor_pmat()`: the ggcorrplot lesson in the description (it works through `cor_pmat()` on `mtcars`), the correlation-test lesson in See Also.
- README: the bare URL in the intro is replaced by the lesson title, the "Colors and theme" section links the ggplot2 colour and theme guides, and a short "Related tutorials" list closes the page.

Every URL was confirmed live at author time: HTTP 200, no redirects, canonical equal to the requested URL. Each link text is the live page H1, and each sentence was checked against what the target page actually covers. `urlchecker::url_check(".")` reports all URLs correct.

## Release metadata

Version 0.3.0 + date, the NEWS heading for the development series renamed to 0.3.0, and cran-comments updated to the 0.3.0 tarball's check results. The spelling wordlist drops a dead entry and gains the words the new links introduce.

## Checks

- `R CMD check --as-cran` on `ggcorrplot_0.3.0.tar.gz`: 0 errors, 0 warnings, 1 note ("unable to verify current time", environmental). The development-version note is gone.
- Same with `_R_CHECK_DEPENDS_ONLY_=true`.
- `Rscript --vanilla -e 'devtools::test()'`: 491 pass, 0 fail, 0 skip (the visual snapshots ran locally and matched).
- `spelling::spell_check_package(".")`: no spelling errors.
